### PR TITLE
Fix closures on non wasm32 targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 
 INSTALL_NODE_VIA_NVM: &INSTALL_NODE_VIA_NVM
   - rustup target add wasm32-unknown-unknown
-  - cargo +nightly install --vers "=0.2.19" wasm-bindgen-cli
+  - cargo +nightly install --vers "=0.2.21" wasm-bindgen-cli
   - curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
   - source ~/.nvm/nvm.sh
   - nvm install v10.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,11 @@ RUN npm install
 RUN cargo build -p isomorphic-client --release --target wasm32-unknown-unknown
 
 # Install WASM bindgen CLI
-RUN curl -OL https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.19/wasm-bindgen-0.2.19-x86_64-unknown-linux-musl.tar.gz
-RUN tar xf wasm-bindgen-0.2.19-x86_64-unknown-linux-musl.tar.gz
-RUN rm wasm-bindgen-0.2.19-x86_64-unknown-linux-musl.tar.gz
-RUN chmod +x wasm-bindgen-0.2.19-x86_64-unknown-linux-musl/wasm-bindgen
-RUN mv wasm-bindgen-0.2.19-x86_64-unknown-linux-musl/wasm-bindgen /usr/local/bin/wasm-bindgen
+RUN curl -OL https://github.com/rustwasm/wasm-bindgen/releases/download/0.2.21/wasm-bindgen-0.2.21-x86_64-unknown-linux-musl.tar.gz
+RUN tar xf wasm-bindgen-0.2.21-x86_64-unknown-linux-musl.tar.gz
+RUN rm wasm-bindgen-0.2.21-x86_64-unknown-linux-musl.tar.gz
+RUN chmod +x wasm-bindgen-0.2.21-x86_64-unknown-linux-musl/wasm-bindgen
+RUN mv wasm-bindgen-0.2.21-x86_64-unknown-linux-musl/wasm-bindgen /usr/local/bin/wasm-bindgen
 
 # Build WASM module
 # TODO: --mode=production . Need to make sure it works locally. If it doesn't try disabling UglifyJS mangling


### PR DESCRIPTION
@qm3ster this just only adds `events` if we're on wasm32 otherwise it ignores