### PR TITLE
Pass event object to custom event handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ fn main () {
     <div id="hello-world", class=*SOME_COMPONENT_CSS,>
       <span>{ "Hey :)" }</span>
       <button
-        !onclick=|| { count_clone.set(count_clone.get() + 1); },
+        !onclick=|_ev| { count_clone.set(count_clone.get() + 1); },
         // CSS in Rust isn't required. You can use regular old
         /* classes just fine! */
         class="btn-bs4 btn-bs4-success",

--- a/book/src/router/README.md
+++ b/book/src/router/README.md
@@ -60,7 +60,7 @@ impl View for HomePage {
     ) -> VirtualNode {
         html! {
             <div id='homepage',>
-                <button !onclick || {
+                <button !onclick |_ev| {
                     store.msg(Msg::Route("/posts/25/authors/jennifer"));
                 },>
                     { "Get the behind the scenes on how" }

--- a/book/src/views/server-side-rendering/how-to-ssr.md
+++ b/book/src/views/server-side-rendering/how-to-ssr.md
@@ -14,7 +14,7 @@ fn main () {
 
   let app = html! {
     <div id='app',>
-      <button !onclick=|| { *count+= 1; },>
+      <button !onclick=|_ev| { *count+= 1; },>
         { "Hello world" }
       </button>
     </div>

--- a/crates/virtual-dom-rs/Cargo.toml
+++ b/crates/virtual-dom-rs/Cargo.toml
@@ -27,6 +27,7 @@ features = [
     "NodeList",
     "Text",
     "Window",
+    "Event",
     "MouseEvent",
     "InputEvent",
 ]
@@ -37,7 +38,6 @@ wasm-bindgen-test = "0.2"
 [dev-dependencies.web-sys]
 version = "0.3"
 features = [
-    "Event",
     "DomTokenList",
     "HtmlInputElement",
 ]

--- a/crates/virtual-dom-rs/src/html_macro.rs
+++ b/crates/virtual-dom-rs/src/html_macro.rs
@@ -42,7 +42,7 @@ pub enum TagType {
 /// use virtual_dom_rs::VirtualNode;
 ///
 /// let click_message = "I was clicked!";
-/// let some_component = html! { <div !onclick=move || { println!("{}", click_message); },></div> };
+/// let some_component = html! { <div !onclick=move |_ev| { println!("{}", click_message); },></div> };
 ///
 /// // Create lists of nodes from data!
 /// let list: Vec<VirtualNode> = [0, 1, 2].iter().map(|index| {
@@ -57,7 +57,7 @@ pub enum TagType {
 /// }).collect();
 ///
 /// let root_node = html! {
-///  <div id="my-app", !onmouseenter=||{},>
+///  <div id="my-app", !onmouseenter=|_ev|{},>
 ///   <span> { "Hello world" } </span>
 ///   <b> { "How are" "you?" } </b>
 ///
@@ -203,7 +203,7 @@ macro_rules! recurse_html {
         // Closure::wrap is not implemented on non wasm32 targets
         #[cfg(target_arch = "wasm32")]
         {
-            let closure = $crate::Closure::wrap(Box::new($callback) as Box<FnMut()>);
+            let closure = $crate::Closure::wrap(Box::new($callback) as Box<FnMut(_)>);
 
             $active_node.as_mut().unwrap().borrow_mut().custom_events.0.insert(
                 stringify!($event_name).to_string(),
@@ -314,7 +314,7 @@ mod tests {
     fn event() {
         test(HTMLMacroTest {
             generated: html!{
-                <div !onclick=|| {},></div>
+                <div !onclick=|_ev| {},></div>
             },
             expected: html!{<div></div>},
             desc: "Events are ignored in non wasm-32 targets",

--- a/crates/virtual-dom-rs/tests/create_element.rs
+++ b/crates/virtual-dom-rs/tests/create_element.rs
@@ -39,7 +39,7 @@ fn click_event() {
 
     let div = html! {
      <div
-         !onclick=move || {
+         !onclick=move |_ev| {
              clicked_clone.set(true);
          },
      >

--- a/crates/virtual-dom-rs/tests/events.rs
+++ b/crates/virtual-dom-rs/tests/events.rs
@@ -15,6 +15,39 @@ extern crate virtual_dom_rs;
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
+fn on_input_custom() {
+    let text = Rc::new(RefCell::new("Start Text".to_string()));
+    let text_clone = Rc::clone(&text);
+
+    let input = html! {
+     <input
+         // On input we'll set our Rc<RefCell<String>> value to the input elements value
+         !oninput=move |event: Event| {
+            let input_elem = event.target().unwrap();
+
+            let input_elem = input_elem.dyn_into::<HtmlInputElement>().unwrap();
+
+            *text_clone.borrow_mut() = input_elem.value();
+         },
+         value="End Text",
+     >
+     </input>
+    };
+
+    let input_event = InputEvent::new("input").unwrap();
+    let input = input.create_element();
+
+    assert_eq!(&*text.borrow(), "Start Text");
+
+    // After dispatching the oninput event our `text` should have a value of the input elements value.
+    (web_sys::EventTarget::from(input))
+        .dispatch_event(input_event.as_ref() as &web_sys::Event)
+        .unwrap();
+
+    assert_eq!(&*text.borrow(), "End Text");
+}
+
+#[wasm_bindgen_test]
 fn on_input() {
     let text = Rc::new(RefCell::new("Start Text".to_string()));
     let text_clone = Rc::clone(&text);

--- a/crates/virtual-node/Cargo.toml
+++ b/crates/virtual-node/Cargo.toml
@@ -21,6 +21,7 @@ features = [
     "NodeList",
     "Text",
     "Window",
+    "Event",
     "MouseEvent",
     "InputEvent",
 ]

--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -383,7 +383,7 @@ impl fmt::Display for VirtualNode {
 
 /// We need a custom implementation of fmt::Debug since FnMut() doesn't
 /// implement debug.
-pub struct CustomEvents(pub HashMap<String, RefCell<Option<Closure<FnMut() -> ()>>>>);
+pub struct CustomEvents(pub HashMap<String, RefCell<Option<Closure<FnMut(Event) -> ()>>>>);
 
 impl PartialEq for CustomEvents {
     // TODO: What should happen here..? And why?
@@ -408,7 +408,7 @@ mod tests {
 //    #[test]
 //    fn to_string() {
 //        let node = html! {
-//        <div id="some-id", !onclick=|| {},>
+//        <div id="some-id", !onclick=|_ev| {},>
 //            <span>
 //                { "Hello world" }
 //            </span>

--- a/examples/isomorphic/app/src/views/home_view.rs
+++ b/examples/isomorphic/app/src/views/home_view.rs
@@ -35,7 +35,7 @@ impl View for HomeView {
           { nav_bar }
 
           <span> { "The button has been clicked: " click_component " times!"} </span>
-          <button !onclick=move|| { store.borrow_mut().msg(&Msg::Click) },>{ "Click me!" }</button>
+          <button !onclick=move|_ev| { store.borrow_mut().msg(&Msg::Click) },>{ "Click me!" }</button>
           <div> { "In this time Ferris has made " click_count " new friends." } </div>
 
         </div>

--- a/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
+++ b/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
@@ -38,7 +38,7 @@ impl View for NavBarItemView {
             <span
                 style=self.style,
                 class=*NAV_BAR_ITEM_CSS,
-                !onclick=move || {
+                !onclick=move |_ev| {
                   store.borrow_mut().msg(&Msg::Path(path.to_string()));
                 },
             >


### PR DESCRIPTION
Followup to Issue #44.

A quick guide to changes:

 * Added "Event" feature to *web-sys* dependencies for *virtual-dom-rs* and and *virtual-node*.
 * Modified `CustomEvents` and the `html!` macro to accept `FnMut(Event) -> ()`.
 * Copy/pasted the *oninput* test, but this time using the generic handler syntax.
 * Changed all the examples I could find to accept an event object (named `_ev`, usually). I may have missed some.

I didn't touch the versions, though this is a breaking change. I dunno how you handle that.

Something I didn't anticipate: even without casting the `Event` to something more specific, this gives the handler immediate access to the element it's tied to, which is a pretty big win by itself.