### PR TITLE
Always create dist folder in iso example

### DIFF
--- a/examples/isomorphic/client/build-wasm.sh
+++ b/examples/isomorphic/client/build-wasm.sh
@@ -3,6 +3,7 @@
 cd $(dirname $0)
 
 mkdir -p build/
+mkdir -p dist/
 
 cargo +nightly build -p isomorphic-client --target wasm32-unknown-unknown &&
   wasm-bindgen --no-modules --no-typescript ../../../target/wasm32-unknown-unknown/debug/isomorphic_client.wasm --out-dir ./build &&

--- a/examples/isomorphic/client/build-wasm.watch.sh
+++ b/examples/isomorphic/client/build-wasm.watch.sh
@@ -3,6 +3,7 @@
 cd $(dirname $0)
 
 mkdir -p build/
+mkdir -p dist/
 
 cargo +nightly watch -w ./ -w ../app \
     -x 'build -p isomorphic-client --target wasm32-unknown-unknown' \


### PR DESCRIPTION
Hello, I tried to run the ismorphic example, but got lots of errors because the `dist` folder doesn't exist on dev run.

```
Listening on port 7878
thread 'arbiter:bfda721a-75c6-485c-8358-33a5d640faa7:actix-net-worker-0' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
...
```

So this edit just creates it on dev build, it's not the best option, feel free to close and tell me if you have something else in mind.