### PR TITLE
Fix replacing of text nodes

### DIFF
--- a/crates/virtual-dom-rs/Cargo.toml
+++ b/crates/virtual-dom-rs/Cargo.toml
@@ -27,6 +27,7 @@ features = [
     "Node",
     "NodeList",
     "Text",
+    "CharacterData",
     "Window",
 ]
 

--- a/crates/virtual-dom-rs/src/patch/apply_patches.rs
+++ b/crates/virtual-dom-rs/src/patch/apply_patches.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use wasm_bindgen::JsCast;
-use web_sys::{Element, Node, Text};
+use web_sys::{Element, Node, Text, CharacterData};
 
 /// Apply all of the patches to our old root node in order to create the new root node
 /// that we desire.
@@ -165,8 +165,8 @@ fn apply_element_patch(node: &Element, patch: &Patch) {
             }
         }
         Patch::ChangeText(_node_idx, _new_node) => unreachable!(
-            "Elements should not receive ChangeText patches. Those should go to Node's"
-        ),
+            "Elements should not receive ChangeText patches."
+        )
     }
 }
 
@@ -175,9 +175,12 @@ fn apply_text_patch(node: &Text, patch: &Patch) {
         Patch::ChangeText(_node_idx, new_node) => {
             node.set_node_value(Some(&new_node.text));
         }
+        Patch::Replace(_node_idx, new_node) => {
+            node.replace_with_with_node_1(&new_node.create_dom_node().node)
+                .expect("Replacing node failed");
+        }
         other => unreachable!(
-            "Nodes should only receive change text patches, not {:?}.
-             All other patches go to Elements", other,
-        ),
+            "Text nodes should only receive ChangeText or Replace patches, not {:?}.", other,
+        )
     }
 }

--- a/crates/virtual-dom-rs/src/patch/apply_patches.rs
+++ b/crates/virtual-dom-rs/src/patch/apply_patches.rs
@@ -6,8 +6,6 @@ use std::collections::HashSet;
 use wasm_bindgen::JsCast;
 use web_sys::{Element, Node, Text};
 
-use crate::{VirtualNode, VText};
-
 /// Apply all of the patches to our old root node in order to create the new root node
 /// that we desire.
 /// This is usually used after diffing two virtual nodes.
@@ -177,8 +175,9 @@ fn apply_text_patch(node: &Text, patch: &Patch) {
         Patch::ChangeText(_node_idx, new_node) => {
             node.set_node_value(Some(&new_node.text));
         }
-        _ => unreachable!(
-            "Nodes should only receive change text patches. All other patches go to Element's"
+        other => unreachable!(
+            "Nodes should only receive change text patches, not {:?}.
+             All other patches go to Elements", other,
         ),
     }
 }

--- a/crates/virtual-dom-rs/tests/diff_patch.rs
+++ b/crates/virtual-dom-rs/tests/diff_patch.rs
@@ -179,5 +179,16 @@ fn text_root_node() {
         new: html! { New text },
         override_expected: None,
     }
-        .test();
+    .test();
+}
+
+#[wasm_bindgen_test]
+fn replace_text_with_element() {
+    DiffPatchTest {
+        desc: "Replacing a text node with an element works",
+        old: html! { <div>a</div> },
+        new: html! { <div><br></div> },
+        override_expected: None,
+    }
+    .test();
 }


### PR DESCRIPTION
Right now we get a panic if a text node is to be replaced with an element, because text nodes don't handle the `Replace` patch.

Here's a failing test (don't merge yet), fix will follow.