### PR TITLE
Accept S: Into<String> as param in VirtualNode::text

### DIFF
--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -107,8 +107,8 @@ impl VirtualNode {
     ///
     /// let div = VirtualNode::text("div");
     /// ```
-    pub fn text(text: &str) -> Self {
-        VirtualNode::Text(text.into())
+    pub fn text<S>(text: S) -> Self where S: Into<String> {
+        VirtualNode::Text(VElement::new(text.into()))
     }
 
     /// Return a [`VElement`] reference, if this is an [`Element`] variant.


### PR DESCRIPTION
This way strings can be moved instead of copied if possible.