### PR TITLE
Store closures for newly appended/replaced nodes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,13 @@ jobs:
       # at all.
       - restore_cache:
           keys:
-            - v1-cargo-cache-test-{{ arch }}-{{ .Branch }}
-            - v1-cargo-cache-test-{{ arch }}
+
+             # When we bump the versions of virtual-dom-rs / virtual-node of the `html-macro-test` ui tests can fail.
+             # This is just because we use [compiletest-rs](https://github.com/laumann/compiletest-rs) which can break down in this case and just requires `cargo clean`.
+             # Or, in the case of CI, just bumping the version prefix of our cache in this file. So if you see `html-macro-test` errors that pass locally after you run `cargo clean` try bumping the CircleCI cache version.
+             # `vN` becomes `vN+1`
+            - v2-cargo-cache-test-{{ arch }}-{{ .Branch }}
+            - v2-cargo-cache-test-{{ arch }}
 
       # Install nightly & wasm
       - run:
@@ -63,12 +68,12 @@ jobs:
 
       # Save cache
       - save_cache:
-          key: v1-cargo-cache-test-{{ arch }}-{{ .Branch }}
+          key: v2-cargo-cache-test-{{ arch }}-{{ .Branch }}
           paths:
             - target
             - /usr/local/cargo
       - save_cache:
-          key: v1-cargo-cache-test-{{ arch }}
+          key: v2-cargo-cache-test-{{ arch }}
           paths:
             - target
             - /usr/local/cargo
@@ -82,8 +87,8 @@ jobs:
       # Multiple caches are used to increase the chance of a cache hit.
       - restore_cache:
           keys:
-            - v1-cargo-cache-docs-{{ arch }}-{{ .Branch }}
-            - v1-cargo-cache-docs-{{ arch }}
+            - v2-cargo-cache-docs-{{ arch }}-{{ .Branch }}
+            - v2-cargo-cache-docs-{{ arch }}
 
       # Install nightly
       - run:
@@ -118,12 +123,12 @@ jobs:
 
       # Save cache
       - save_cache:
-          key: v1-cargo-cache-docs-{{ arch }}-{{ .Branch }}
+          key: v2-cargo-cache-docs-{{ arch }}-{{ .Branch }}
           paths:
             - target
             - /usr/local/cargo
       - save_cache:
-          key: v1-cargo-cache-docs-{{ arch }}
+          key: v2-cargo-cache-docs-{{ arch }}
           paths:
             - target
             - /usr/local/cargo

--- a/crates/html-macro-test/src/lib.rs
+++ b/crates/html-macro-test/src/lib.rs
@@ -3,7 +3,7 @@
 
 use html_macro::{html, text};
 use std::collections::HashMap;
-use virtual_node::{VirtualNode, VElement};
+use virtual_node::{VElement, VirtualNode};
 
 struct HtmlMacroTest<'a> {
     desc: &'a str,

--- a/crates/virtual-dom-rs/src/diff/mod.rs
+++ b/crates/virtual-dom-rs/src/diff/mod.rs
@@ -100,7 +100,8 @@ fn diff_recursive<'a, 'b>(
             let new_child_count = new_element.children.len();
 
             if new_child_count > old_child_count {
-                let append_patch: Vec<&'a VirtualNode> = new_element.children[old_child_count..].iter().collect();
+                let append_patch: Vec<&'a VirtualNode> =
+                    new_element.children[old_child_count..].iter().collect();
                 patches.push(Patch::AppendChildren(*cur_node_idx, append_patch))
             }
 
@@ -121,8 +122,8 @@ fn diff_recursive<'a, 'b>(
                 }
             }
         }
-        (VirtualNode::Text(_), VirtualNode::Element(_)) |
-        (VirtualNode::Element(_), VirtualNode::Text(_)) => {
+        (VirtualNode::Text(_), VirtualNode::Element(_))
+        | (VirtualNode::Element(_), VirtualNode::Text(_)) => {
             unreachable!("Unequal variant discriminants should already have been handled");
         }
     };
@@ -148,7 +149,7 @@ use self::diff_test_case::*;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{html, VirtualNode, VText};
+    use crate::{html, VText, VirtualNode};
     use std::collections::HashMap;
 
     #[test]

--- a/crates/virtual-dom-rs/src/patch/mod.rs
+++ b/crates/virtual-dom-rs/src/patch/mod.rs
@@ -1,7 +1,7 @@
 //! Our Patch enum is intentionally kept in it's own file for easy inclusion into
 //! The Percy Book.
 
-use crate::{VirtualNode, VText};
+use crate::{VText, VirtualNode};
 use std::collections::HashMap;
 
 mod apply_patches;

--- a/crates/virtual-dom-rs/tests/closures.rs
+++ b/crates/virtual-dom-rs/tests/closures.rs
@@ -29,8 +29,10 @@ fn closure_not_dropped() {
     {
         let mut input = make_input_component(Rc::clone(&text));
         input
-            .as_velement_mut().expect("Not an element")
-            .props.insert("id".into(), "old-input-elem".into());
+            .as_velement_mut()
+            .expect("Not an element")
+            .props
+            .insert("id".into(), "old-input-elem".into());
 
         let mount = document.create_element("div").unwrap();
         mount.set_id("mount");
@@ -51,8 +53,10 @@ fn closure_not_dropped() {
         // that dom_updater maintains Rc's to those Closures.
         let mut new_node = make_input_component(Rc::clone(&text));
         new_node
-            .as_velement_mut().expect("Not an element")
-            .props.insert("id".into(), "new-input-elem".into());
+            .as_velement_mut()
+            .expect("Not an element")
+            .props
+            .insert("id".into(), "new-input-elem".into());
 
         dom_updater.update(new_node);
     }

--- a/crates/virtual-dom-rs/tests/create_element.rs
+++ b/crates/virtual-dom-rs/tests/create_element.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::*;
-use web_sys::{Event, MouseEvent, EventTarget, Element};
+use web_sys::{Element, Event, EventTarget, MouseEvent};
 
 use virtual_dom_rs::prelude::*;
 

--- a/crates/virtual-dom-rs/tests/diff_patch_test_case/mod.rs
+++ b/crates/virtual-dom-rs/tests/diff_patch_test_case/mod.rs
@@ -3,7 +3,7 @@
 use console_error_panic_hook;
 use virtual_dom_rs::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::{Node, Element};
+use web_sys::{Element, Node};
 
 /// A test case that both diffing and patching are working in a real browser
 pub struct DiffPatchTest<'a> {
@@ -48,11 +48,6 @@ impl<'a> DiffPatchTest<'a> {
             _ => panic!("Unhandled node type"),
         };
 
-        assert_eq!(
-            &actual_outer_html,
-            &expected_outer_html,
-            "{}",
-            self.desc
-        );
+        assert_eq!(&actual_outer_html, &expected_outer_html, "{}", self.desc);
     }
 }

--- a/crates/virtual-dom-rs/tests/dom_updater.rs
+++ b/crates/virtual-dom-rs/tests/dom_updater.rs
@@ -1,8 +1,13 @@
 //! Ensure that our DomUpdater maintains Rc's to closures so that they work even
 //! after dropping virtual dom nodes.
+//!
+//! To run all tests in this file:
+//!
+//! wasm-pack test crates/virtual-dom-rs --chrome --headless -- --test dom_updater
 
 #![feature(proc_macro_hygiene)]
 
+use console_error_panic_hook;
 use std::cell::RefCell;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -21,9 +26,12 @@ wasm_bindgen_test_configure!(run_in_browser);
 // diffing and patching.
 #[wasm_bindgen_test]
 fn patches_dom() {
+    console_error_panic_hook::set_once();
+
     let document = web_sys::window().unwrap().document().unwrap();
 
     let vdom = html! { <div></div> };
+
     let mut dom_updater = DomUpdater::new(vdom);
 
     let new_vdom = html! { <div id="patched"></div> };
@@ -34,4 +42,106 @@ fn patches_dom() {
         .unwrap()
         .append_child(&dom_updater.root_node());
     assert_eq!(document.query_selector("#patched").unwrap().is_some(), true);
+}
+
+// When you replace a DOM node with another DOM node we need to make sure that the closures
+// from the new DOM node are stored by the DomUpdater otherwise they'll get dropped and
+// won't work.
+#[wasm_bindgen_test]
+fn updates_active_closure_on_replace() {
+    console_error_panic_hook::set_once();
+
+    let document = web_sys::window().unwrap().document().unwrap();
+    let body = document.body().unwrap();
+
+    let old = html! { <div> </div> };
+    let mut dom_updater = DomUpdater::new_append_to_mount(old, &body);
+
+    let text = Rc::new(RefCell::new("Start Text".to_string()));
+    let text_clone = Rc::clone(&text);
+
+    let id = "update-active-closures-on-replace";
+
+    {
+        let replace_node = html! {
+         <input
+            id=id
+            oninput=move |event: Event| {
+               let input_elem = event.target().unwrap();
+               let input_elem = input_elem.dyn_into::<HtmlInputElement>().unwrap();
+               *text_clone.borrow_mut() = input_elem.value();
+            }
+            value="End Text"
+         >
+        };
+
+        // New node replaces old node.
+        // We are testing that we've stored this new node's closures even though `new` will be dropped
+        // at the end of this block.
+        dom_updater.update(replace_node);
+    }
+
+    let input_event = InputEvent::new("input").unwrap();
+
+    assert_eq!(&*text.borrow(), "Start Text");
+
+    // After dispatching the oninput event our `text` should have a value of the input elements value.
+    let input = document.get_element_by_id(&id).unwrap();
+    web_sys::EventTarget::from(input)
+        .dispatch_event(&input_event)
+        .unwrap();
+
+    assert_eq!(&*text.borrow(), "End Text");
+}
+
+// When you replace a DOM node with another DOM node we need to make sure that the closures
+// from the new DOM node are stored by the DomUpdater otherwise they'll get dropped and
+// won't work.
+#[wasm_bindgen_test]
+fn updates_active_closures_on_append() {
+    console_error_panic_hook::set_once();
+
+    let document = web_sys::window().unwrap().document().unwrap();
+    let body = document.body().unwrap();
+
+    let old = html! { <div> </div> };
+    let mut dom_updater = DomUpdater::new_append_to_mount(old, &body);
+
+    let text = Rc::new(RefCell::new("Start Text".to_string()));
+    let text_clone = Rc::clone(&text);
+
+    let id = "update-active-closures-on-append";
+
+    {
+        let append_node = html! {
+        <div>
+           <input
+              id=id
+              oninput=move |event: Event| {
+                 let input_elem = event.target().unwrap();
+                 let input_elem = input_elem.dyn_into::<HtmlInputElement>().unwrap();
+                 *text_clone.borrow_mut() = input_elem.value();
+              }
+              value="End Text"
+           >
+         </div>
+        };
+
+        // New node gets appended into the DOM.
+        // We are testing that we've stored this new node's closures even though `new` will be dropped
+        // at the end of this block.
+        dom_updater.update(append_node);
+    }
+
+    let input_event = InputEvent::new("input").unwrap();
+
+    assert_eq!(&*text.borrow(), "Start Text");
+
+    // After dispatching the oninput event our `text` should have a value of the input elements value.
+    let input = document.get_element_by_id(id).unwrap();
+    web_sys::EventTarget::from(input)
+        .dispatch_event(&input_event)
+        .unwrap();
+
+    assert_eq!(&*text.borrow(), "End Text");
 }

--- a/crates/virtual-dom-rs/tests/events.rs
+++ b/crates/virtual-dom-rs/tests/events.rs
@@ -15,8 +15,9 @@ use virtual_dom_rs::prelude::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
+// Make sure that we successfully attach an event listener and see it work.
 #[wasm_bindgen_test]
-fn on_input_custom() {
+fn on_input() {
     let text = Rc::new(RefCell::new("Start Text".to_string()));
     let text_clone = Rc::clone(&text);
 

--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -9,13 +9,13 @@
 //
 // Around in order to get rid of dependencies that we don't need in non wasm32 targets
 
-use std::collections::{HashSet,HashMap};
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::rc::Rc;
 
 pub mod virtual_node_test_utils;
 
-use web_sys::{self, Text, Element, Node, EventTarget};
+use web_sys::{self, Element, EventTarget, Node, Text};
 
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
@@ -25,18 +25,19 @@ use lazy_static::lazy_static;
 use std::ops::Deref;
 use std::sync::Mutex;
 
-
 // Used to uniquely identify elements that contain closures so that the DomUpdater can
 // look them up by their unique id.
 // When the DomUpdater sees that the element no longer exists it will drop all of it's
 // Rc'd Closures for those events.
 lazy_static! {
     static ref ELEM_UNIQUE_ID: Mutex<u32> = Mutex::new(0);
-
     static ref SELF_CLOSING_TAGS: HashSet<&'static str> = [
-        "area", "base", "br", "col", "hr", "img", "input", "link", "meta",
-        "param", "command", "keygen", "source",
-    ].iter().cloned().collect();
+        "area", "base", "br", "col", "hr", "img", "input", "link", "meta", "param", "command",
+        "keygen", "source",
+    ]
+    .iter()
+    .cloned()
+    .collect();
 }
 
 /// When building your views you'll typically use the `html!` macro to generate
@@ -94,7 +95,10 @@ impl VirtualNode {
     ///
     /// let div = VirtualNode::element("div");
     /// ```
-    pub fn element<S>(tag: S) -> Self where S: Into<String> {
+    pub fn element<S>(tag: S) -> Self
+    where
+        S: Into<String>,
+    {
         VirtualNode::Element(VElement::new(tag))
     }
 
@@ -107,7 +111,10 @@ impl VirtualNode {
     ///
     /// let div = VirtualNode::text("div");
     /// ```
-    pub fn text<S>(text: S) -> Self where S: Into<String> {
+    pub fn text<S>(text: S) -> Self
+    where
+        S: Into<String>,
+    {
         VirtualNode::Text(VText::new(text.into()))
     }
 
@@ -159,14 +166,19 @@ impl VirtualNode {
     /// together with potentially related closures) for this virtual node.
     pub fn create_dom_node(&self) -> CreatedNode<Node> {
         match self {
-            VirtualNode::Text(text_node) => CreatedNode::without_closures(text_node.create_text_node()),
+            VirtualNode::Text(text_node) => {
+                CreatedNode::without_closures(text_node.create_text_node())
+            }
             VirtualNode::Element(element_node) => element_node.create_element_node().into(),
         }
     }
 }
 
 impl VElement {
-    pub fn new<S>(tag: S) -> Self where S: Into<String> {
+    pub fn new<S>(tag: S) -> Self
+    where
+        S: Into<String>,
+    {
         VElement {
             tag: tag.into(),
             props: HashMap::new(),
@@ -248,7 +260,7 @@ impl VElement {
                         .unwrap();
 
                     previous_node_was_text = true;
-                },
+                }
                 VirtualNode::Element(element_node) => {
                     previous_node_was_text = false;
 
@@ -258,18 +270,23 @@ impl VElement {
                     closures.extend(child.closures);
 
                     element.append_child(&child_elem).unwrap();
-                },
+                }
             }
         });
 
-        CreatedNode { node: element, closures }
+        CreatedNode {
+            node: element,
+            closures,
+        }
     }
-
 }
 
 impl VText {
     /// Create an new `VText` instance with the specified text.
-    pub fn new<S>(text: S) -> Self where S: Into<String> {
+    pub fn new<S>(text: S) -> Self
+    where
+        S: Into<String>,
+    {
         VText { text: text.into() }
     }
 
@@ -341,7 +358,9 @@ impl From<VElement> for VirtualNode {
 
 impl From<&str> for VText {
     fn from(text: &str) -> Self {
-        VText { text: text.to_string() }
+        VText {
+            text: text.to_string(),
+        }
     }
 }
 

--- a/crates/virtual-node/src/virtual_node_test_utils.rs
+++ b/crates/virtual-node/src/virtual_node_test_utils.rs
@@ -1,6 +1,6 @@
 //! A collection of functions that are useful for unit testing your html! views.
 
-use crate::{VirtualNode, VElement};
+use crate::{VElement, VirtualNode};
 
 impl VirtualNode {
     /// Get a vector of all of the VirtualNode children / grandchildren / etc of
@@ -31,27 +31,23 @@ impl VirtualNode {
         // Get descendants recursively
         let mut descendants: Vec<&'a VirtualNode> = vec![];
         match self {
-            VirtualNode::Text(_) => { /* nothing to do */ },
+            VirtualNode::Text(_) => { /* nothing to do */ }
             VirtualNode::Element(element_node) => {
                 for child in element_node.children.iter() {
                     get_descendants(&mut descendants, child);
                 }
-            },
+            }
         }
 
         // Filter descendants
         descendants
             .into_iter()
-            .filter(|vn: &&'a VirtualNode| {
-                match vn {
-                    VirtualNode::Text(_) => false,
-                    VirtualNode::Element(element_node) => {
-                        match element_node.props.get("label") {
-                            Some(label) => filter(label),
-                            None => false,
-                        }
-                    },
-                }
+            .filter(|vn: &&'a VirtualNode| match vn {
+                VirtualNode::Text(_) => false,
+                VirtualNode::Element(element_node) => match element_node.props.get("label") {
+                    Some(label) => filter(label),
+                    None => false,
+                },
             })
             .collect()
     }
@@ -83,12 +79,12 @@ impl VirtualNode {
 fn get_descendants<'a>(descendants: &mut Vec<&'a VirtualNode>, node: &'a VirtualNode) {
     descendants.push(node);
     match node {
-        VirtualNode::Text(_) => { /* nothing to do */ },
+        VirtualNode::Text(_) => { /* nothing to do */ }
         VirtualNode::Element(element_node) => {
             for child in element_node.children.iter() {
                 get_descendants(descendants, child);
             }
-        },
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #70

We weren't holding on to the closures that were created for DOM nodes in the AppendChildren / Replace patches so they just wouldn't work as soon as your VirtualNode got dropped.