### PR TITLE
Fix readme example and missing Rc import

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ use web_sys;
 
 use css_rs_macro::css;
 use virtual_dom_rs::prelude::*;
-use std::cell::Cell;
 
 #[wasm_bindgen(start)]
 pub fn start() {

--- a/crates/html-macro/src/parser.rs
+++ b/crates/html-macro/src/parser.rs
@@ -84,7 +84,7 @@ impl HtmlParser {
                                   let closure = wasm_bindgen::prelude::Closure::wrap(
                                       Box::new(#value) as Box<FnMut(_)>
                                   );
-                                  let closure_rc = Rc::new(closure);
+                                  let closure_rc = std::rc::Rc::new(closure);
                                   #var_name_node.as_velement_mut().expect("Not an element")
                                       .events.0.insert(#key.to_string(), closure_rc);
                                 }


### PR DESCRIPTION
## About

Fixes warning that import of `Cell` is unused and compilation failed due to use of undeclared type or module `Rc`. 

Using `rustc 1.34.0-nightly (146aa60f3 2019-02-18)` and the dependencies listed in the readme. 