### PR TITLE
Rename props with attrs

### DIFF
--- a/crates/html-macro-test/src/lib.rs
+++ b/crates/html-macro-test/src/lib.rs
@@ -33,7 +33,7 @@ fn one_prop() {
     let mut props = HashMap::new();
     props.insert("id".to_string(), "hello-world".to_string());
     let mut expected = VElement::new("div");
-    expected.props = props;
+    expected.attrs = props;
 
     HtmlMacroTest {
         desc: "One property",

--- a/crates/html-macro-test/src/lib.rs
+++ b/crates/html-macro-test/src/lib.rs
@@ -29,14 +29,14 @@ fn empty_div() {
 }
 
 #[test]
-fn one_prop() {
-    let mut props = HashMap::new();
-    props.insert("id".to_string(), "hello-world".to_string());
+fn one_attr() {
+    let mut attrs = HashMap::new();
+    attrs.insert("id".to_string(), "hello-world".to_string());
     let mut expected = VElement::new("div");
-    expected.attrs = props;
+    expected.attrs = attrs;
 
     HtmlMacroTest {
-        desc: "One property",
+        desc: "One attribute",
         generated: html! { <div id="hello-world"></div> },
         expected: expected.into(),
     }

--- a/crates/html-macro/src/parser.rs
+++ b/crates/html-macro/src/parser.rs
@@ -95,7 +95,7 @@ impl HtmlParser {
                         _ => {
                             let insert_attribute = quote! {
                                 #var_name_node.as_velement_mut().expect("Not an element")
-                                    .props.insert(#key.to_string(), #value.to_string());
+                                    .attrs.insert(#key.to_string(), #value.to_string());
                             };
                             tokens.push(insert_attribute);
                         }

--- a/crates/virtual-dom-rs/src/diff/mod.rs
+++ b/crates/virtual-dom-rs/src/diff/mod.rs
@@ -68,33 +68,33 @@ fn diff_recursive<'a, 'b>(
             let mut remove_attributes: Vec<&str> = vec![];
 
             // TODO: -> split out into func
-            for (new_prop_name, new_prop_val) in new_element.attrs.iter() {
-                match old_element.attrs.get(new_prop_name) {
-                    Some(ref old_prop_val) => {
-                        if old_prop_val != &new_prop_val {
-                            add_attributes.insert(new_prop_name, new_prop_val);
+            for (new_attr_name, new_attr_val) in new_element.attrs.iter() {
+                match old_element.attrs.get(new_attr_name) {
+                    Some(ref old_attr_val) => {
+                        if old_attr_val != &new_attr_val {
+                            add_attributes.insert(new_attr_name, new_attr_val);
                         }
                     }
                     None => {
-                        add_attributes.insert(new_prop_name, new_prop_val);
+                        add_attributes.insert(new_attr_name, new_attr_val);
                     }
                 };
             }
 
             // TODO: -> split out into func
-            for (old_prop_name, old_prop_val) in old_element.attrs.iter() {
-                if add_attributes.get(&old_prop_name[..]).is_some() {
+            for (old_attr_name, old_attr_val) in old_element.attrs.iter() {
+                if add_attributes.get(&old_attr_name[..]).is_some() {
                     continue;
                 };
 
-                match new_element.attrs.get(old_prop_name) {
-                    Some(ref new_prop_val) => {
-                        if new_prop_val != &old_prop_val {
-                            remove_attributes.push(old_prop_name);
+                match new_element.attrs.get(old_attr_name) {
+                    Some(ref new_attr_val) => {
+                        if new_attr_val != &old_attr_val {
+                            remove_attributes.push(old_attr_name);
                         }
                     }
                     None => {
-                        remove_attributes.push(old_prop_name);
+                        remove_attributes.push(old_attr_name);
                     }
                 };
             }

--- a/crates/virtual-dom-rs/src/diff/mod.rs
+++ b/crates/virtual-dom-rs/src/diff/mod.rs
@@ -33,8 +33,8 @@ fn diff_recursive<'a, 'b>(
         // TODO: More robust key support. This is just an early stopgap to allow you to force replace
         // an element... say if it's event changed. Just change the key name for now.
         // In the future we want keys to be used to create a Patch::ReOrder to re-order siblings
-        if old_element.props.get("key").is_some()
-            && old_element.props.get("key") != new_element.props.get("key")
+        if old_element.attrs.get("key").is_some()
+            && old_element.attrs.get("key") != new_element.attrs.get("key")
         {
             replace = true;
         }
@@ -68,8 +68,8 @@ fn diff_recursive<'a, 'b>(
             let mut remove_attributes: Vec<&str> = vec![];
 
             // TODO: -> split out into func
-            for (new_prop_name, new_prop_val) in new_element.props.iter() {
-                match old_element.props.get(new_prop_name) {
+            for (new_prop_name, new_prop_val) in new_element.attrs.iter() {
+                match old_element.attrs.get(new_prop_name) {
                     Some(ref old_prop_val) => {
                         if old_prop_val != &new_prop_val {
                             add_attributes.insert(new_prop_name, new_prop_val);
@@ -82,12 +82,12 @@ fn diff_recursive<'a, 'b>(
             }
 
             // TODO: -> split out into func
-            for (old_prop_name, old_prop_val) in old_element.props.iter() {
+            for (old_prop_name, old_prop_val) in old_element.attrs.iter() {
                 if add_attributes.get(&old_prop_name[..]).is_some() {
                     continue;
                 };
 
-                match new_element.props.get(old_prop_name) {
+                match new_element.attrs.get(old_prop_name) {
                     Some(ref new_prop_val) => {
                         if new_prop_val != &old_prop_val {
                             remove_attributes.push(old_prop_name);

--- a/crates/virtual-dom-rs/tests/closures.rs
+++ b/crates/virtual-dom-rs/tests/closures.rs
@@ -31,7 +31,7 @@ fn closure_not_dropped() {
         input
             .as_velement_mut()
             .expect("Not an element")
-            .props
+            .attrs
             .insert("id".into(), "old-input-elem".into());
 
         let mount = document.create_element("div").unwrap();
@@ -55,7 +55,7 @@ fn closure_not_dropped() {
         new_node
             .as_velement_mut()
             .expect("Not an element")
-            .props
+            .attrs
             .insert("id".into(), "new-input-elem".into());
 
         dom_updater.update(new_node);

--- a/crates/virtual-dom-rs/tests/create_element.rs
+++ b/crates/virtual-dom-rs/tests/create_element.rs
@@ -21,7 +21,7 @@ fn nested_divs() {
 }
 
 #[wasm_bindgen_test]
-fn div_with_properties() {
+fn div_with_attributes() {
     let vdiv = html! { <div id="id-here" class="two classes"></div> };
     let div: Element = vdiv.create_dom_node().node.unchecked_into();
 

--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -54,7 +54,7 @@ lazy_static! {
 ///
 /// TODO: Make all of these fields private and create accessor methods
 /// TODO: Create a builder to create instances of VirtualNode::Element with
-/// props and children without having to explicitly create a VElement
+/// attrs and children without having to explicitly create a VElement
 #[derive(PartialEq)]
 pub enum VirtualNode {
     /// An element node (node type `ELEMENT_NODE`).
@@ -71,7 +71,7 @@ pub enum VirtualNode {
 pub struct VElement {
     /// The HTML tag, such as "div"
     pub tag: String,
-    /// HTML props such as id, class, style, etc
+    /// HTML attributes such as id, class, style, etc
     pub attrs: HashMap<String, String>,
     /// Events that will get added to your real DOM element via `.addEventListener`
     pub events: Events,
@@ -393,7 +393,7 @@ impl fmt::Debug for VElement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "Element(<{}>, props: {:?}, children: {:?})",
+            "Element(<{}>, attrs: {:?}, children: {:?})",
             self.tag, self.attrs, self.children,
         )
     }
@@ -410,8 +410,8 @@ impl fmt::Display for VElement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<{}", self.tag).unwrap();
 
-        for (prop, value) in self.attrs.iter() {
-            write!(f, r#" {}="{}""#, prop, value)?;
+        for (attr, value) in self.attrs.iter() {
+            write!(f, r#" {}="{}""#, attr, value)?;
         }
 
         write!(f, ">")?;

--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -72,7 +72,7 @@ pub struct VElement {
     /// The HTML tag, such as "div"
     pub tag: String,
     /// HTML props such as id, class, style, etc
-    pub props: HashMap<String, String>,
+    pub attrs: HashMap<String, String>,
     /// Events that will get added to your real DOM element via `.addEventListener`
     pub events: Events,
     /// The children of this `VirtualNode`. So a <div> <em></em> </div> structure would
@@ -181,7 +181,7 @@ impl VElement {
     {
         VElement {
             tag: tag.into(),
-            props: HashMap::new(),
+            attrs: HashMap::new(),
             events: Events(HashMap::new()),
             children: vec![],
         }
@@ -200,7 +200,7 @@ impl VElement {
         let element = document.create_element(&self.tag).unwrap();
         let mut closures = HashMap::new();
 
-        self.props.iter().for_each(|(name, value)| {
+        self.attrs.iter().for_each(|(name, value)| {
             element
                 .set_attribute(name, value)
                 .expect("Set element attribute in create element");
@@ -394,7 +394,7 @@ impl fmt::Debug for VElement {
         write!(
             f,
             "Element(<{}>, props: {:?}, children: {:?})",
-            self.tag, self.props, self.children,
+            self.tag, self.attrs, self.children,
         )
     }
 }
@@ -410,7 +410,7 @@ impl fmt::Display for VElement {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<{}", self.tag).unwrap();
 
-        for (prop, value) in self.props.iter() {
+        for (prop, value) in self.attrs.iter() {
             write!(f, r#" {}="{}""#, prop, value)?;
         }
 

--- a/crates/virtual-node/src/virtual_node_test_utils.rs
+++ b/crates/virtual-node/src/virtual_node_test_utils.rs
@@ -123,10 +123,10 @@ mod tests {
     fn label_equals() {
         let span = VirtualNode::element("span");
 
-        let mut props = HashMap::new();
-        props.insert("label".to_string(), "hello".to_string());
+        let mut attrs = HashMap::new();
+        attrs.insert("label".to_string(), "hello".to_string());
         let mut em = VElement::new("em");
-        em.attrs = props;
+        em.attrs = attrs;
 
         let mut html = VElement::new("div");
         html.children.push(span);

--- a/crates/virtual-node/src/virtual_node_test_utils.rs
+++ b/crates/virtual-node/src/virtual_node_test_utils.rs
@@ -44,7 +44,7 @@ impl VirtualNode {
             .into_iter()
             .filter(|vn: &&'a VirtualNode| match vn {
                 VirtualNode::Text(_) => false,
-                VirtualNode::Element(element_node) => match element_node.props.get("label") {
+                VirtualNode::Element(element_node) => match element_node.attrs.get("label") {
                     Some(label) => filter(label),
                     None => false,
                 },
@@ -126,7 +126,7 @@ mod tests {
         let mut props = HashMap::new();
         props.insert("label".to_string(), "hello".to_string());
         let mut em = VElement::new("em");
-        em.props = props;
+        em.attrs = props;
 
         let mut html = VElement::new("div");
         html.children.push(span);


### PR DESCRIPTION
While reading source code of virtual_dom_rs, I was confused by VElement's `props`. [the term "properties" and "attributes" has slightly different meanings in DOM](https://stackoverflow.com/a/6004028). VElement's one named `props` but what it contains is "attributes" rather than "properties" I think.

Fixes #77 