### PR TITLE
Interpolate text into html! macro, remove text! macro

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
           name: Build docs
           command: >
             (cd book && mdbook build)
-            && cargo doc --no-deps -p virtual-dom-rs -p css-rs-macro -p html-macro
+            && cargo doc --no-deps -p virtual-dom-rs -p css-rs-macro -p html-macro -p router-rs-macro
             && cp -R target/doc book/book/api
       - persist_to_workspace:
           root: book

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ In a browser our application renders to an `HtmlElement`, and on the server our 
 
 - [virtual-dom-rs API docs](https://chinedufn.github.io/percy/api/virtual_dom_rs/macro.html.html)
 
+- [html-macro API docs](https://chinedufn.github.io/percy/api/html_rs_macro)
+
 - [css-rs-macro API docs](https://chinedufn.github.io/percy/api/css_rs_macro)
+
+- [router-rs-macro API docs](https://chinedufn.github.io/percy/api/router_rs_macro)
+
 
 ## Getting Started
 

--- a/book/src/contributing/internal-design/sibling-text-nodes.md
+++ b/book/src/contributing/internal-design/sibling-text-nodes.md
@@ -8,7 +8,7 @@ For example, when you have a component that looks like this:
 ```rust
 use virtual_dom_rs::prelude::*;
 
-let world = text!("world");
+let world = "world";
 
 let sibling_text_nodes = html! { <div> hello {world} </div> };
 ```
@@ -40,7 +40,7 @@ Note the new `<!--ptns-->` comment node. Here's what `virtual_dom_rs`'s `createE
 If we later wanted to patch the DOM with a new component
 
 ```
-let different_text = text!("there");
+let different_text = "there";
 let sibling_text_nodes = html! { <div> hello {different_text} } </div> };
 ```
 

--- a/book/src/html-macro/html-macro.md
+++ b/book/src/html-macro/html-macro.md
@@ -14,15 +14,15 @@ html!{
 
 ### Text variables
 
-Text variables must be wrapped in the `text!` macro.
+Text variables must be wrapped in braces.
 
 ```rust
 use virtual_dom_rs::prelude::*;
 
-let text_var = " world"
+let text_var = " world";
 
 html! {
-  Hello { text!(text_var) }
+  Hello { <div> { text_var } </div> }
 }
 ```
 
@@ -85,7 +85,7 @@ let list = vec!["1", "2", "3"]
     .map(|item_num| {
       html! { 
         <li>
-          List item number { text!(item_num) }
+          List item number { item_num }
         </li>
       }
     });

--- a/crates/html-macro-test/src/lib.rs
+++ b/crates/html-macro-test/src/lib.rs
@@ -1,9 +1,9 @@
 #![feature(proc_macro_hygiene)]
 #![cfg(test)]
 
-use html_macro::{html, text};
+use html_macro::html;
 use std::collections::HashMap;
-use virtual_node::{VElement, VirtualNode};
+use virtual_node::{IterableNodes, VElement, VirtualNode};
 
 struct HtmlMacroTest<'a> {
     desc: &'a str,
@@ -237,13 +237,25 @@ fn type_attribute() {
 }
 
 #[test]
-fn text_macro() {
-    let text_var = "some text";
+fn text_variable_root() {
+    let text = "hello world";
 
     HtmlMacroTest {
-        desc: "text! creates text from variables",
-        generated: text!(text_var),
-        expected: VirtualNode::text("some text"),
+        desc: "Text variable root",
+        generated: html! { { text } },
+        expected: VirtualNode::text("hello world"),
+    }
+    .test()
+}
+
+#[test]
+fn text_variable_child() {
+    let text = "world";
+
+    HtmlMacroTest {
+        desc: "Text variable child",
+        generated: html! { <div> { text } </div> },
+        expected: html! { <div> world </div> },
     }
     .test()
 }

--- a/crates/html-macro/README.md
+++ b/crates/html-macro/README.md
@@ -12,7 +12,7 @@ fn main () {
        <div onclick=|_ev: web_sys::MouseEvent| {}>
           You can type text right into the elements
           { component }
-          { text!(text_var) }
+          { text_var }
        </div>
     };
     println!("{}", node);

--- a/crates/html-macro/src/lib.rs
+++ b/crates/html-macro/src/lib.rs
@@ -2,22 +2,11 @@ extern crate proc_macro;
 
 use crate::parser::HtmlParser;
 use crate::tag::Tag;
-use quote::quote;
 use syn::parse::{Parse, ParseStream, Result};
-use syn::{parse_macro_input, Expr};
+use syn::parse_macro_input;
 
 mod parser;
 mod tag;
-
-#[proc_macro]
-pub fn text(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let text: Expr = syn::parse(input).expect("Text variable");
-    let text = quote! {
-        VirtualNode::text(#text)
-    };
-
-    text.into()
-}
 
 /// Used to generate VirtualNode's from a TokenStream.
 ///

--- a/crates/html-macro/src/parser.rs
+++ b/crates/html-macro/src/parser.rs
@@ -212,7 +212,7 @@ impl HtmlParser {
                     //
                     // html { { some_node }  }
                     let node = quote! {
-                        let node_0 = #stmt.into();
+                        let node_0: VirtualNode = #stmt.into();
                     };
                     tokens.push(node);
                 } else {

--- a/crates/html-macro/src/parser.rs
+++ b/crates/html-macro/src/parser.rs
@@ -212,11 +212,13 @@ impl HtmlParser {
                     //
                     // html { { some_node }  }
                     let node = quote! {
-                        let node_0 = #stmt;
+                        let node_0 = #stmt.into();
                     };
                     tokens.push(node);
                 } else {
-                    // Here we handle a block being a descendant within some html! call
+                    // Here we handle a block being a descendant within some html! call.
+                    //
+                    // The descendant should implement Into<IterableNodes>
                     //
                     // html { <div> { some_node } </div> }
 
@@ -224,7 +226,7 @@ impl HtmlParser {
                     let node_name = Ident::new(node_name.as_str(), stmt.span());
 
                     let nodes = quote! {
-                        let #node_name = #stmt;
+                        let #node_name: IterableNodes = #stmt.into();
                     };
                     tokens.push(nodes);
 
@@ -247,7 +249,6 @@ impl HtmlParser {
     ///  3. Append the children to this node
     ///  4. Move on to the next node (as in, go back to step 1)
     pub fn finish(&mut self) -> proc_macro2::TokenStream {
-        let parent_stack = &mut self.parent_stack;
         let node_order = &mut self.node_order;
         let parent_to_children = &mut self.parent_to_children;
         let tokens = &mut self.tokens;

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -170,7 +170,7 @@ fn parse_block(input: &mut ParseStream) -> Result<Tag> {
 
 fn parse_text_node(input: &mut ParseStream) -> Result<Tag> {
     // Continue parsing tokens until we see a closing tag <
-    let mut text_tokens = TokenStream::new();
+    let text_tokens = TokenStream::new();
 
     let mut text = "".to_string();
 
@@ -181,12 +181,7 @@ fn parse_text_node(input: &mut ParseStream) -> Result<Tag> {
             break;
         }
 
-        let is_comma = input.peek(Token![,]);
-
-        // TODO: If we peek a token that we aren't confident that we can choose the correct
-        // spacing for almost all of the time just print a compiler error telling the user
-        // to use the text macro instead of text tokens...
-        //  { text!("My text") }
+        // TODO: Ditch this and build text with proper spacing by using span start/end locations
         if input.peek(Token![,]) {
             let _: TokenTree = input.parse()?;
             text += ",";

--- a/crates/router-rs-macro-test/src/book_example.rs
+++ b/crates/router-rs-macro-test/src/book_example.rs
@@ -9,10 +9,10 @@ use virtual_dom_rs::prelude::*;
 #[route(path = "/users/:id/favorite-meal/:meal")]
 fn route_data_and_param(id: u16, state: Provided<SomeState>, meal: Meal) -> VirtualNode {
     let id = format!("{}", id);
-    let meal = text!(format!("{:#?}", meal));
+    let meal = format!("{:#?}", meal);
 
     html! {
-        <div> User { text!(id) } loves { meal} </div>
+        <div> User { id } loves { meal } </div>
     }
 }
 

--- a/crates/router-rs/CHANGELOG.md
+++ b/crates/router-rs/CHANGELOG.md
@@ -15,6 +15,6 @@ _Here we list notable things that have been merged into the master branch but ha
 
 - ...
 
-## 0.2.0
+## 0.2.0 - Mar 4, 2019
 
 - [added] Introduced the `#[route(path = "/...")]` macro in [#95](https://github.com/chinedufn/percy/pull/95)

--- a/crates/router-rs/src/provided.rs
+++ b/crates/router-rs/src/provided.rs
@@ -1,11 +1,6 @@
 use crate::router::Router;
 use std::any::TypeId;
-use std::cell::Ref;
-use std::cell::RefCell;
-use std::mem::discriminant;
-use std::mem::Discriminant;
 use std::ops::Deref;
-use std::ops::DerefMut;
 use std::rc::Rc;
 
 /// Data that was provided by the developer.

--- a/crates/router-rs/src/route.rs
+++ b/crates/router-rs/src/route.rs
@@ -1,10 +1,8 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Error;
 use std::fmt::Formatter;
 use std::str::FromStr;
 use virtual_dom_rs::VText;
-use virtual_dom_rs::View;
 use virtual_dom_rs::VirtualNode;
 
 /// Enables a type to be used as a route paramer
@@ -79,7 +77,7 @@ pub struct Route {
 
 impl Debug for Route {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        f.write_str(self.route_definition);
+        f.write_str(self.route_definition)?;
         Ok(())
     }
 }
@@ -157,16 +155,6 @@ impl Route {
         }
 
         true
-    }
-
-    /// Given an incoming path, create the `View` that uses that path data.
-    ///
-    /// For example.. if our defined path is `/users/:id`
-    /// and our incoming path is `/users/5`
-    ///
-    /// Our view will end up getting created with `id: 5`
-    pub fn view(&self, incoming_path: &str) -> VirtualNode {
-        VirtualNode::Text(VText::new("TODO: Implement this"))
     }
 
     /// Given an incoming path and a param_key, get the RouteParam

--- a/crates/router-rs/src/route.rs
+++ b/crates/router-rs/src/route.rs
@@ -181,8 +181,7 @@ mod tests {
     use super::*;
     use std::cell::RefCell;
     use std::rc::Rc;
-    use virtual_dom_rs::html;
-    use virtual_dom_rs::VirtualNode;
+    use virtual_dom_rs::prelude::*;
 
     struct MyView {
         id: u32,

--- a/crates/router-rs/src/router.rs
+++ b/crates/router-rs/src/router.rs
@@ -1,12 +1,10 @@
 //! Powers routing for frontend web applications
 
-use crate::provided::Provided;
 use crate::Route;
 use std::any::Any;
 use std::any::TypeId;
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::mem::Discriminant;
 use std::rc::Rc;
 use virtual_dom_rs::prelude::*;
 

--- a/crates/virtual-dom-rs/CHANGELOG.md
+++ b/crates/virtual-dom-rs/CHANGELOG.md
@@ -15,6 +15,17 @@ _Here we list notable things that have been merged into the master branch but ha
 
 - ...
 
+## 0.6.5 - Mar 4, 2019
+
+- [added] Start supporting braced text in the `html!` macro
+- [removed] Removed the `text!` macro
+
+ ```rust
+ let hello = "hello world";
+ html! { {hello} }
+ ```
+
+
 ## 0.6.4 - Feb 24, 2019
 
 - [fixed] Using the `html!` macro to create an event now uses the fully qualified path to `std::rc::Rc`

--- a/crates/virtual-dom-rs/Cargo.toml
+++ b/crates/virtual-dom-rs/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 js-sys = "0.3"
 wasm-bindgen = "0.2.33"
-virtual-node = { path = "../virtual-node", version = "0.2.0" }
+virtual-node = { path = "../virtual-node", version = "0.2.1" }
 html-macro = { path = "../html-macro", version = "0.1.1"}
 
 [dependencies.web-sys]

--- a/crates/virtual-dom-rs/Cargo.toml
+++ b/crates/virtual-dom-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtual-dom-rs"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 description = "A standalone Virtual DOM creation, diffing and patching implementation"
 keywords = ["virtual", "dom", "wasm", "assembly", "webassembly"]

--- a/crates/virtual-dom-rs/src/dom_updater.rs
+++ b/crates/virtual-dom-rs/src/dom_updater.rs
@@ -2,7 +2,6 @@
 
 use crate::diff::diff;
 use crate::patch::patch;
-use crate::patch::Patch;
 use std::collections::HashMap;
 use virtual_node::DynClosure;
 use virtual_node::VirtualNode;
@@ -90,8 +89,6 @@ impl DomUpdater {
         let active_closures = patch(self.root_node.clone(), &patches).unwrap();
 
         self.active_closures.extend(active_closures);
-
-        let closures = format!("{}", self.active_closures.len());
 
         self.current_vdom = new_vdom;
     }

--- a/crates/virtual-dom-rs/src/lib.rs
+++ b/crates/virtual-dom-rs/src/lib.rs
@@ -30,7 +30,6 @@ mod view;
 pub use crate::view::*;
 
 pub use html_macro::html;
-pub use html_macro::text;
 
 mod dom_updater;
 pub use self::dom_updater::DomUpdater;
@@ -42,6 +41,6 @@ pub mod prelude {
     pub use crate::view::View;
     pub use crate::VirtualNode;
     pub use html_macro::html;
-    pub use html_macro::text;
     pub use std::vec::IntoIter;
+    pub use virtual_node::IterableNodes;
 }

--- a/crates/virtual-dom-rs/src/patch/apply_patches.rs
+++ b/crates/virtual-dom-rs/src/patch/apply_patches.rs
@@ -4,10 +4,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use crate::dom_updater::ActiveClosures;
-use virtual_node::DynClosure;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
-use web_sys::{CharacterData, Element, Node, Text};
+use web_sys::{Element, Node, Text};
 
 /// Apply all of the patches to our old root node in order to create the new root node
 /// that we desire.
@@ -47,7 +46,7 @@ pub fn patch<N: Into<Node>>(root_node: N, patches: &Vec<Patch>) -> Result<Active
         }
 
         if let Some(text_node) = text_nodes_to_patch.get(&patch_node_idx) {
-            apply_text_patch(&text_node, &patch);
+            apply_text_patch(&text_node, &patch)?;
             continue;
         }
 
@@ -123,7 +122,7 @@ fn find_nodes(
 }
 
 fn apply_element_patch(node: &Element, patch: &Patch) -> Result<ActiveClosures, JsValue> {
-    let mut active_closures = HashMap::new();
+    let active_closures = HashMap::new();
 
     match patch {
         Patch::AddAttributes(_node_idx, attributes) => {

--- a/crates/virtual-node/Cargo.toml
+++ b/crates/virtual-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtual-node"
-version = "0.2.0"
+version = "0.2.1"
 description = "A standalone Virtual DOM"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 keywords = ["virtual", "dom", "wasm", "assembly", "webassembly"]

--- a/examples/isomorphic/app/src/lib.rs
+++ b/examples/isomorphic/app/src/lib.rs
@@ -4,8 +4,6 @@
 extern crate serde_derive;
 
 use router_rs::prelude::*;
-use serde;
-use serde_json;
 use std::cell::RefCell;
 use std::rc::Rc;
 use virtual_dom_rs::prelude::*;
@@ -14,7 +12,6 @@ mod store;
 pub use crate::state::*;
 pub use crate::store::*;
 use crate::views::*;
-use std::collections::HashMap;
 
 mod state;
 mod views;

--- a/examples/isomorphic/app/src/views/home_view.rs
+++ b/examples/isomorphic/app/src/views/home_view.rs
@@ -26,8 +26,7 @@ impl View for HomeView {
         let click_count = self.store.borrow().click_count();
         let click_count = &*click_count.to_string();
 
-        let click_component =
-            html! { <strong style="font-size: 30px">{ text!(click_count) }</strong> };
+        let click_component = html! { <strong style="font-size: 30px">{ click_count }</strong> };
 
         html! {
         <div>
@@ -38,7 +37,7 @@ impl View for HomeView {
           <button onclick=move|_: u8| { store.borrow_mut().msg(&Msg::Click) }>
             Click me!
           </button>
-          <div> In this time Ferris has made { text!(click_count) } new friends. </div>
+          <div> In this time Ferris has made { click_count } new friends. </div>
 
         </div>
         }

--- a/examples/isomorphic/app/src/views/nav_bar_view/mod.rs
+++ b/examples/isomorphic/app/src/views/nav_bar_view/mod.rs
@@ -1,5 +1,4 @@
 use crate::store::Store;
-use crate::Msg;
 use css_rs_macro::css;
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
+++ b/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
@@ -1,5 +1,4 @@
 use crate::store::Store;
-use crate::Msg;
 use css_rs_macro::css;
 use std::cell::RefCell;
 use std::rc::Rc;


### PR DESCRIPTION
## What

This PR makes it much easier to interpolate text variables into your HTML.

#### Before (bad)

```rust
let my_text = "hello world";

html! { <div> { text!(my_text) } </div> }
```

#### After (good)

```rust
let my_text = "hello world";

html! { <div> { my_text } </div> }
```

## Why

Needing a macro for such a common thing was a poor experience