### PR TITLE
Preserve spacing around text nodes and braces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs:
           keys:
             # Checksum ensures that when we update versions for our `html-macro` dependencies we clear our cache, otherwise
             # compiletest-rs can error when the target directory has multiple versions of a crate.
-            - v4-cargo-cache-test-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
-            - v4-cargo-cache-test-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+            - v5-cargo-cache-test-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+            - v5-cargo-cache-test-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
 
       # Install nightly & wasm
       - run:
@@ -65,12 +65,12 @@ jobs:
 
       # Save cache
       - save_cache:
-          key: v4-cargo-cache-test-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+          key: v5-cargo-cache-test-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
           paths:
             - target
             - /usr/local/cargo
       - save_cache:
-          key: v4-cargo-cache-test-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+          key: v5-cargo-cache-test-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
           paths:
             - target
             - /usr/local/cargo
@@ -84,8 +84,8 @@ jobs:
       # Multiple caches are used to increase the chance of a cache hit.
       - restore_cache:
           keys:
-            - v4-cargo-cache-docs-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
-            - v4-cargo-cache-docs-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+            - v5-cargo-cache-docs-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+            - v5-cargo-cache-docs-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
 
       # Install nightly
       - run:
@@ -120,12 +120,12 @@ jobs:
 
       # Save cache
       - save_cache:
-          key: v4-cargo-cache-docs-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+          key: v5-cargo-cache-docs-{{ arch }}-{{ .Branch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
           paths:
             - target
             - /usr/local/cargo
       - save_cache:
-          key: v4-cargo-cache-docs-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
+          key: v5-cargo-cache-docs-{{ arch }}-{{ checksum "./crates/html-macro/Cargo.toml" }}-{{ checksum "./crates/virtual-dom-rs/Cargo.toml" }}
           paths:
             - target
             - /usr/local/cargo

--- a/README.md
+++ b/README.md
@@ -104,9 +104,11 @@ pub fn start() {
 
     let mut dom_updater = DomUpdater::new_append_to_mount(start_view, &body);
 
+    let greetings = "Hello, World!";
+
     let end_view = html! {
        <div class="big blue">
-          <strong>Hello, World!</strong>
+          <strong>{ greetings }</strong>
 
           <button
             class=MY_COMPONENT_CSS
@@ -118,7 +120,6 @@ pub fn start() {
           </button>
        </div>
     };
-
 
     dom_updater.update(end_view);
 }

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Writing html!](./html-macro/README.md)
     - [Writing html!](./html-macro/html-macro.md)
     - [Compile Time Errors](./html-macro/compile-time-errors.md)
+    - [Working with Text](./html-macro/text/README.md)
   - [Virtual DOM](./virtual-dom/README.md)
     - [Unit Testing your Views](./virtual-dom/unit-testing-views.md)
   - [Server Side Rendering (SSR)](./views/server-side-rendering/README.md)

--- a/book/src/html-macro/text/README.md
+++ b/book/src/html-macro/text/README.md
@@ -3,8 +3,46 @@
 Rather than needing you to wrap your text in `"` quotation marks,
 the `html-macro` will work with raw unquoted text.
 
-Here are some examples of how the `html!` macro works with text:
+```rust
+fn main () {
+    let interpolated_var = "interpolate text variables.";
+
+    let example = html! {
+       <div>
+            Text can be typed directly into your HTML.
+            <div>Or you can also {interpolated_var}</div>
+       </div>
+    };
+}
+```
+
+You should always get the same spacing (or lack there of) between text and/or elements as you would
+if you were working in a regular old `.html` file.
+
+When it comes to interpolated variables, we base spacing on the spacing outside of the brackets.
 
 ```rust
+fn main () {
+    let text = "hello";
+
+    html! { <div>{ hello }</div> }; // <div>hello</div>
+    html! { <div>{hello}</div> }; // <div>hello</div>
+
+    html! { <div> { hello } </div> }; // <div> hello </div>
+    html! { <div> {hello} </div> }; // <div> hello </div>
+
+    html! { <div>{hello} </div> }; // <div>hello </div>
+    html! { <div> {hello}</div> }; // <div> hello</div>
+}
+```
+
+## More Examples
+
+Here are a bunch of examples showing you what happens when you try and mix
+text nodes / variables / elements.
+
+```rust
+// Imported into book from crates/html-macro-test/src/text.rs
+
 {{ #include ../../../../crates/html-macro-test/src/text.rs }}
 ```

--- a/book/src/html-macro/text/README.md
+++ b/book/src/html-macro/text/README.md
@@ -24,6 +24,8 @@ fn main () {
 You should always get the same spacing (or lack there of) between text and other elements as you would
 if you were working in a regular old `.html` file.
 
+We'll preserve newline characters so that `white-space: pre-wrap` etc will work as expected.
+
 When it comes to interpolated variables, we base spacing on the spacing outside of the braces, not the
 inside.
 
@@ -40,19 +42,8 @@ fn main () {
     html! { <div> {hello} </div> }; // <div> hello </div>
 
     html! { <div>{hello} </div> }; // <div>hello </div>
-    html! { <div> {hello}</div> }; // <div> hello</div>
+    html! { <div>   {hello}</div> }; // <div>   hello</div>
 }
-```
-
-## More Examples
-
-Here are a bunch of examples showing you what happens when you try and mix
-text nodes / variables / elements.
-
-```rust
-// Imported into book from crates/html-macro-test/src/text.rs
-
-{{ #include ../../../../crates/html-macro-test/src/text.rs }}
 ```
 
 [Text]: https://developer.mozilla.org/en-US/docs/Web/API/Text

--- a/book/src/html-macro/text/README.md
+++ b/book/src/html-macro/text/README.md
@@ -1,0 +1,10 @@
+# Working with Text
+
+Rather than needing you to wrap your text in `"` quotation marks,
+the `html-macro` will work with raw unquoted text.
+
+Here are some examples of how the `html!` macro works with text:
+
+```rust
+{{ #include ../../../../crates/html-macro-test/src/text.rs }}
+```

--- a/book/src/html-macro/text/README.md
+++ b/book/src/html-macro/text/README.md
@@ -1,25 +1,33 @@
 # Working with Text
 
-Rather than needing you to wrap your text in `"` quotation marks,
-the `html-macro` will work with raw unquoted text.
+One of the most popular types of nodes in the DOM is the [Text] node, and the `html! macro
+focuses heavily on making them as easy to create as possible.
+
+You can just type unquoted text into the `html!` macro and neighboring text will get combined into a single `Text` node, much
+like the way that web browsers handle text from html documents.
 
 ```rust
 fn main () {
-    let interpolated_var = "interpolate text variables.";
+    let interpolated_text = "interpolate text variables.";
 
     let example = html! {
        <div>
             Text can be typed directly into your HTML.
-            <div>Or you can also {interpolated_var}</div>
+            <div>Or you can also {interpolated_text}</div>
        </div>
     };
 }
 ```
 
-You should always get the same spacing (or lack there of) between text and/or elements as you would
+## Preserving Space Between Blocks
+
+You should always get the same spacing (or lack there of) between text and other elements as you would
 if you were working in a regular old `.html` file.
 
-When it comes to interpolated variables, we base spacing on the spacing outside of the brackets.
+When it comes to interpolated variables, we base spacing on the spacing outside of the braces, not the
+inside.
+
+Let's illustrate:
 
 ```rust
 fn main () {
@@ -46,3 +54,5 @@ text nodes / variables / elements.
 
 {{ #include ../../../../crates/html-macro-test/src/text.rs }}
 ```
+
+[Text]: https://developer.mozilla.org/en-US/docs/Web/API/Text

--- a/crates/html-macro-test/src/lib.rs
+++ b/crates/html-macro-test/src/lib.rs
@@ -1,9 +1,10 @@
 #![feature(proc_macro_hygiene)]
-#![cfg(test)]
 
 use html_macro::html;
 use std::collections::HashMap;
 use virtual_node::{IterableNodes, VElement, VirtualNode};
+
+mod text;
 
 struct HtmlMacroTest<'a> {
     desc: &'a str,
@@ -209,135 +210,10 @@ fn vec_of_nodes() {
     .test();
 }
 
-// FIXME: Move text tests into a separate file and import into book under
-// html! section
-
-#[test]
-fn text_root_node() {
-    HtmlMacroTest {
-        desc: "Text as root node",
-        generated: html! { some text },
-        expected: VirtualNode::text("some text"),
-    }
-    .test()
-}
-
 /// Just make sure that this compiles since type is a keyword
 #[test]
 fn type_attribute() {
     html! { <link rel="stylesheet" type="text/css" href="/app.css" /> };
-}
-
-#[test]
-fn text_variable_root() {
-    let text = "hello world";
-
-    HtmlMacroTest {
-        desc: "Text variable root",
-        generated: html! { { text } },
-        expected: VirtualNode::text("hello world"),
-    }
-    .test()
-}
-
-#[test]
-fn text_variable_child() {
-    let text = "world";
-
-    assert_eq!(
-        &html! { <div>{ text }</div> }.to_string(),
-        "<div>world</div>"
-    )
-}
-
-#[test]
-fn text_space_after_start_tag() {
-    assert_eq!(
-        &html! { <div> After Start Tag</div> }.to_string(),
-        "<div> After Start Tag</div>"
-    )
-}
-
-#[test]
-fn text_space_before_end_tag() {
-    assert_eq!(
-        &html! { <div>Before End Tag </div> }.to_string(),
-        "<div>Before End Tag </div>"
-    )
-}
-
-#[test]
-fn text_space_before_block() {
-    let text = "Before Block";
-
-    assert_eq!(
-        &html! { <div> {text}</div> }.to_string(),
-        "<div> Before Block</div>"
-    )
-}
-
-#[test]
-fn text_space_after_block() {
-    let text = "Hello";
-
-    assert_eq!(
-        &html! { <div>{text} </div> }.to_string(),
-        "<div>Hello </div>"
-    )
-}
-
-#[test]
-fn text_space_in_block_ignored() {
-    let text = "Hello";
-
-    assert_eq!(
-        &html! { <div>{ text }</div> }.to_string(),
-        "<div>Hello</div>"
-    )
-}
-
-#[test]
-fn text_multiple_text_no_space_between() {
-    let hello = "Hello";
-    let world = "World";
-
-    assert_eq!(
-        &html! { <div>{ hello }{ world }</div> }.to_string(),
-        "<div>HelloWorld</div>"
-    )
-}
-
-#[test]
-fn text_multiple_text_space_between() {
-    let hello = "Hello";
-    let world = "World";
-
-    assert_eq!(
-        &html! { <div>{ hello } { world }</div> }.to_string(),
-        "<div>Hello World</div>"
-    )
-}
-
-#[test]
-fn text_multiple_text_space_around() {
-    let hello = "Hello";
-    let world = "World";
-
-    assert_eq!(
-        &html! { <div> { hello }{ world } </div> }.to_string(),
-        "<div> HelloWorld </div>"
-    )
-}
-
-#[test]
-fn text_multiple_text_space_between_around() {
-    let hello = "Hello";
-    let world = "World";
-
-    assert_eq!(
-        &html! { <div> { hello } { world } </div> }.to_string(),
-        "<div> Hello World </div>"
-    )
 }
 
 // Verify that all of our self closing tags work as both.

--- a/crates/html-macro-test/src/lib.rs
+++ b/crates/html-macro-test/src/lib.rs
@@ -177,7 +177,8 @@ fn text_next_to_block() {
     .test();
 }
 
-/// Ensure that we maintain the correct spacing around punctuation tokens
+/// Ensure that we maintain the correct spacing around punctuation tokens, since
+/// they resolve into a separate TokenStream during parsing.
 #[test]
 fn punctuation_token() {
     let text = "Hello, World";

--- a/crates/html-macro-test/src/text.rs
+++ b/crates/html-macro-test/src/text.rs
@@ -7,24 +7,22 @@ use virtual_node::{IterableNodes, VElement, VirtualNode};
 
 #[test]
 fn text_root_node() {
-    HtmlMacroTest {
-        desc: "Text as root node",
-        generated: html! { some text },
-        expected: VirtualNode::text("some text"),
-    }
-    .test()
+    assert_eq!(&html! { some text }.to_string(), "some text");
 }
 
 #[test]
 fn text_variable_root() {
     let text = "hello world";
 
-    HtmlMacroTest {
-        desc: "Text variable root",
-        generated: html! { { text } },
-        expected: VirtualNode::text("hello world"),
-    }
-    .test()
+    assert_eq!(&html! { { text } }.to_string(), "hello world");
+}
+
+#[test]
+fn raw_string_literal() {
+    assert_eq!(
+        &html! { <div>{ r#"Hello World"# }</div> }.to_string(),
+        "<div>Hello World</div>"
+    );
 }
 
 #[test]

--- a/crates/html-macro-test/src/text.rs
+++ b/crates/html-macro-test/src/text.rs
@@ -157,3 +157,19 @@ fn text_tokens_in_between_vars_space_around_between() {
         "<div> Hello Space World </div>"
     )
 }
+
+#[test]
+fn text_space_before_next_open_tag() {
+    assert_eq!(
+        &html! { <div>Hello <img /> world</div> }.to_string(),
+        "<div>Hello <img> world</div>"
+    )
+}
+
+#[test]
+fn text_no_space_before_open_tag() {
+    assert_eq!(
+        &html! { <div>Hello<img /> world</div> }.to_string(),
+        "<div>Hello<img> world</div>"
+    )
+}

--- a/crates/html-macro-test/src/text.rs
+++ b/crates/html-macro-test/src/text.rs
@@ -1,0 +1,161 @@
+#![feature(proc_macro_hygiene)]
+
+use crate::HtmlMacroTest;
+use html_macro::html;
+use std::collections::HashMap;
+use virtual_node::{IterableNodes, VElement, VirtualNode};
+
+#[test]
+fn text_root_node() {
+    HtmlMacroTest {
+        desc: "Text as root node",
+        generated: html! { some text },
+        expected: VirtualNode::text("some text"),
+    }
+    .test()
+}
+
+#[test]
+fn text_variable_root() {
+    let text = "hello world";
+
+    HtmlMacroTest {
+        desc: "Text variable root",
+        generated: html! { { text } },
+        expected: VirtualNode::text("hello world"),
+    }
+    .test()
+}
+
+#[test]
+fn text_variable_child() {
+    let text = "world";
+
+    assert_eq!(
+        &html! { <div>{ text }</div> }.to_string(),
+        "<div>world</div>"
+    )
+}
+
+#[test]
+fn text_space_after_start_tag() {
+    assert_eq!(
+        &html! { <div> After Start Tag</div> }.to_string(),
+        "<div> After Start Tag</div>"
+    )
+}
+
+#[test]
+fn text_space_before_end_tag() {
+    assert_eq!(
+        &html! { <div>Before End Tag </div> }.to_string(),
+        "<div>Before End Tag </div>"
+    )
+}
+
+#[test]
+fn text_space_before_block() {
+    let text = "Before Block";
+
+    assert_eq!(
+        &html! { <div> {text}</div> }.to_string(),
+        "<div> Before Block</div>"
+    )
+}
+
+#[test]
+fn text_space_after_block() {
+    let text = "Hello";
+
+    assert_eq!(
+        &html! { <div>{text} </div> }.to_string(),
+        "<div>Hello </div>"
+    )
+}
+
+#[test]
+fn text_space_in_block_ignored() {
+    let text = "Hello";
+
+    assert_eq!(
+        &html! { <div>{ text }</div> }.to_string(),
+        "<div>Hello</div>"
+    )
+}
+
+#[test]
+fn text_multiple_text_no_space_between() {
+    let hello = "Hello";
+    let world = "World";
+
+    assert_eq!(
+        &html! { <div>{ hello }{ world }</div> }.to_string(),
+        "<div>HelloWorld</div>"
+    )
+}
+
+#[test]
+fn text_multiple_text_space_between() {
+    let hello = "Hello";
+    let world = "World";
+
+    assert_eq!(
+        &html! { <div>{ hello } { world }</div> }.to_string(),
+        "<div>Hello World</div>"
+    )
+}
+
+#[test]
+fn text_multiple_text_space_around() {
+    let hello = "Hello";
+    let world = "World";
+
+    assert_eq!(
+        &html! { <div> { hello }{ world } </div> }.to_string(),
+        "<div> HelloWorld </div>"
+    )
+}
+
+#[test]
+fn text_multiple_text_space_between_around() {
+    let hello = "Hello";
+    let world = "World";
+
+    assert_eq!(
+        &html! { <div> { hello } { world } </div> }.to_string(),
+        "<div> Hello World </div>"
+    )
+}
+
+#[test]
+fn text_tokens_in_between_vars_without_space() {
+    let hello = "Hello";
+    let world = "World";
+
+    assert_eq!(
+        &html! { <div>{ hello }NoSpace{ world }</div> }.to_string(),
+        "<div>HelloNoSpaceWorld</div>"
+    )
+}
+
+#[test]
+fn text_tokens_in_between_vars_with_space() {
+    let hello = "Hello";
+    let world = "World";
+
+    assert_eq!(
+        &html! { <div>{ hello } Space { world }</div> }.to_string(),
+        "<div>Hello Space World</div>"
+    )
+}
+
+#[test]
+fn text_tokens_in_between_vars_space_around_between() {
+    let hello = "Hello";
+    let world = "World";
+
+    assert_eq!(
+        &html! { <div> { hello } Space { world } </div> }.to_string(),
+        "<div> Hello Space World </div>"
+    )
+}

--- a/crates/html-macro-ui/test.rs
+++ b/crates/html-macro-ui/test.rs
@@ -18,7 +18,6 @@ fn main() {
     config.mode = "ui".parse().expect("invalid mode");
     let mut me = env::current_exe().unwrap();
     me.pop();
-    eprintln!("me = {:#?}", me);
     config.target_rustcflags = Some(format!("-L {}", me.display()));
     let src = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     config.src_base = src;

--- a/crates/html-macro/src/lib.rs
+++ b/crates/html-macro/src/lib.rs
@@ -17,8 +17,16 @@ pub fn html(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let mut html_parser = HtmlParser::new();
 
-    for tag in parsed.tags.into_iter() {
-        html_parser.push_tag(tag);
+    let parsed_tags_len = parsed.tags.len();
+
+    for (idx, tag) in parsed.tags.iter().enumerate() {
+        let mut next_tag = None;
+
+        if parsed_tags_len - 1 > idx {
+            next_tag = Some(&parsed.tags[idx + 1])
+        }
+
+        html_parser.push_tag(tag, next_tag);
     }
 
     html_parser.finish().into()

--- a/crates/html-macro/src/lib.rs
+++ b/crates/html-macro/src/lib.rs
@@ -19,6 +19,10 @@ pub fn html(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let parsed_tags_len = parsed.tags.len();
 
+    // Iterate over all of our parsed tags and push them into our HtmlParser one by one.
+    //
+    // As we go out HtmlParser will maintain some heuristics about what we've done so far
+    // since that will sometimes inform how to parse the next token.
     for (idx, tag) in parsed.tags.iter().enumerate() {
         let mut next_tag = None;
 

--- a/crates/html-macro/src/parser/braced.rs
+++ b/crates/html-macro/src/parser/braced.rs
@@ -40,17 +40,6 @@ impl HtmlParser {
             _ => false,
         };
 
-        let node_idx = &mut self.current_node_idx;
-        let parent_to_children = &mut self.parent_to_children;
-        let parent_stack = &mut self.parent_stack;
-        let tokens = &mut self.tokens;
-        let node_order = &mut self.node_order;
-
-        let open_tag_end = match self.recent_span_locations.most_recent_open_tag_end.as_ref() {
-            Some(open_tag_end) => Some((open_tag_end.line, open_tag_end.column)),
-            None => None,
-        };
-
         // We ignore this check if the last tag kind was text since the text
         // parser will already handle inserting spaces before and after text.
         let last_tag_kind_was_text = self.last_tag_kind == Some(TagKind::Text);
@@ -61,18 +50,19 @@ impl HtmlParser {
 
         // TODO: Only allow one statement per block. Put a quote_spanned! compiler error if
         // there is more than 1 statement. Add a UI test for this.
-        block.stmts.iter().enumerate().for_each(|(stmt_idx, stmt)| {
-            if *node_idx == 0 {
+        block.stmts.iter().for_each(|stmt| {
+            if self.current_node_idx == 0 {
                 // Here we handle a block being the root node of an `html!` call
                 //
                 // html { { some_node }  }
                 let node = quote! {
                     let node_0: VirtualNode = #stmt.into();
                 };
-                tokens.push(node);
+                self.push_tokens(node);
             } else {
-                // If this is the first node in the block we'll check to see if there is a space
-                // between this block and the previous closing tag.
+                // We'll check to see if there is a space between this block and the previous open
+                // tag's closing brace.
+                //
                 // If so we'll insert a VirtualNode::text(" ") just in case the block contains
                 // a text element. This way there will be space before the text.
                 //
@@ -82,33 +72,13 @@ impl HtmlParser {
                 // html! { <div>{some_var}</div> }  -> would not get a " " inserted
                 //
                 // html! { <div> {some_var}</div> } -> would get a " " inserted
-                if stmt_idx == 0 && !last_tag_kind_was_text && !last_tag_kind_was_brace {
-                    if let Some(open_tag_end) = open_tag_end {
-                        if open_tag_end.0 != brace_span.start().line
-                            || brace_span.start().column - open_tag_end.1 > 0
-                        {
-                            // FIXME BEFORE MERGE: Add a method to generate a new node that
-                            // increments our node_idx. Pass a span to that method
-                            let node_name = format!("node_{}", node_idx);
-                            let node_name = Ident::new(node_name.as_str(), brace_span.clone());
-
-                            let space = quote! {
-                                let #node_name: IterableNodes = VirtualNode::text(" ").into();
-                            };
-                            tokens.push(space);
-
-                            // TODO BEFORE MERGE: Exact same code repeated below. Normalize
-
-                            let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
-
-                            parent_to_children
-                                .get_mut(&parent_idx)
-                                .expect("Parent of this text node")
-                                .push(*node_idx);
-                            node_order.push(*node_idx);
-
-                            *node_idx += 1;
-                        }
+                if let Some(open_tag_end) =
+                    self.recent_span_locations.most_recent_open_tag_end.as_ref()
+                {
+                    if self.last_tag_kind == Some(TagKind::Open)
+                        && self.separated_by_whitespace(open_tag_end, brace_span)
+                    {
+                        self.push_virtual_text_space_tokens(stmt.span());
                     }
                 }
 
@@ -117,53 +87,14 @@ impl HtmlParser {
                 // The descendant should implement Into<IterableNodes>
                 //
                 // html { <div> { some_node } </div> }
-
-                let node_name = format!("node_{}", node_idx);
-                let node_name = Ident::new(node_name.as_str(), stmt.span());
-
-                let nodes = quote! {
-                    let #node_name: IterableNodes = #stmt.into();
-                };
-                tokens.push(nodes);
-
-                // TODO BEFORE MERGE: Exact same code repeated above. Normalize
-
-                let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
-
-                parent_to_children
-                    .get_mut(&parent_idx)
-                    .expect("Parent of this text node")
-                    .push(*node_idx);
-                node_order.push(*node_idx);
-
-                *node_idx += 1;
+                self.push_iterable_nodes(stmt);
 
                 if should_insert_space_after {
-                    // FIXME BEFORE MERGE: Add a method to generate a new node that
-                    // increments our node_idx. Pass a span to that method
-                    let node_name = format!("node_{}", node_idx);
-                    let node_name = Ident::new(node_name.as_str(), brace_span.clone());
-
-                    let space = quote! {
-                        let #node_name: IterableNodes = VirtualNode::text(" ").into();
-                    };
-                    tokens.push(space);
-
-                    // TODO BEFORE MERGE: Exact same code repeated below. Normalize
-
-                    let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
-
-                    parent_to_children
-                        .get_mut(&parent_idx)
-                        .expect("Parent of this text node")
-                        .push(*node_idx);
-                    node_order.push(*node_idx);
-
-                    *node_idx += 1;
+                    self.push_virtual_text_space_tokens(stmt.span())
                 }
             }
         });
 
-        self.set_most_recent_block_start(brace_span);
+        self.set_most_recent_block_start(brace_span.clone());
     }
 }

--- a/crates/html-macro/src/parser/braced.rs
+++ b/crates/html-macro/src/parser/braced.rs
@@ -1,6 +1,6 @@
 use crate::parser::HtmlParser;
 use crate::tag::{Tag, TagKind};
-use proc_macro2::{Ident, Span};
+use proc_macro2::Span;
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::Block;

--- a/crates/html-macro/src/parser/braced.rs
+++ b/crates/html-macro/src/parser/braced.rs
@@ -1,20 +1,84 @@
 use crate::parser::HtmlParser;
-use proc_macro2::Ident;
+use crate::tag::{Tag, TagKind};
+use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::spanned::Spanned;
 use syn::Block;
 
 impl HtmlParser {
     /// Parse an incoming Tag::Braced text node
-    pub(crate) fn parse_braced(&mut self, block: Box<Block>) {
-        let idx = &mut self.current_idx;
+    pub(crate) fn parse_braced(
+        &mut self,
+        block: &Box<Block>,
+        brace_span: &Span,
+        next_tag: Option<&Tag>,
+    ) {
+        let node_idx = &mut self.current_node_idx;
         let parent_to_children = &mut self.parent_to_children;
         let parent_stack = &mut self.parent_stack;
         let tokens = &mut self.tokens;
         let node_order = &mut self.node_order;
 
-        block.stmts.iter().for_each(|stmt| {
-            if *idx == 0 {
+        let open_tag_end = match self.recent_span_locations.most_recent_open_tag_end.as_ref() {
+            Some(open_tag_end) => Some((open_tag_end.line, open_tag_end.column)),
+            None => None,
+        };
+
+        let mut should_insert_space_after = false;
+
+        // FIXME: Move into function
+        if let Some(next_tag) = next_tag {
+            if let Tag::Close {
+                first_angle_bracket_span,
+                ..
+            } = next_tag
+            {
+                let spans_on_different_lines =
+                    first_angle_bracket_span.start().line != brace_span.end().line;
+
+                if spans_on_different_lines {
+                    should_insert_space_after = true;
+                } else {
+                    let space_between_spans =
+                        first_angle_bracket_span.start().column - brace_span.end().column > 0;
+                    if space_between_spans {
+                        should_insert_space_after = true;
+                    }
+                }
+            }
+
+            if let Tag::Braced {
+                brace_span: next_brace_span,
+                ..
+            } = next_tag
+            {
+                let spans_on_different_lines =
+                    next_brace_span.start().line != brace_span.end().line;
+
+                if spans_on_different_lines {
+                    should_insert_space_after = true;
+                } else {
+                    let space_between_spans =
+                        next_brace_span.start().column - brace_span.end().column > 0;
+                    if space_between_spans {
+                        should_insert_space_after = true;
+                    }
+                }
+            }
+        };
+
+        // We ignore this check if the last tag kind was text since the text
+        // parser will already handle inserting spaces before and after text.
+        let last_tag_kind_was_text = self.last_tag_kind == Some(TagKind::Text);
+
+        // We ignore this check if the last tag kind was brace since the previous brace
+        // parser will already handle inserting spaces before this current brace if needed.
+        let last_tag_kind_was_brace = self.last_tag_kind == Some(TagKind::Braced);
+
+        // TODO: Only allow one statement per block. Put a quote_spanned! compiler error if
+        // there is more than 1 statement. Add a UI test for this.
+        block.stmts.iter().enumerate().for_each(|(stmt_idx, stmt)| {
+            if *node_idx == 0 {
                 // Here we handle a block being the root node of an `html!` call
                 //
                 // html { { some_node }  }
@@ -23,13 +87,54 @@ impl HtmlParser {
                 };
                 tokens.push(node);
             } else {
+                // If this is the first node in the block we'll check to see if there is a space
+                // between this block and the previous closing tag.
+                // If so we'll insert a VirtualNode::text(" ") just in case the block contains
+                // a text element. This way there will be space before the text.
+                //
+                // let some_var = "hello"
+                // let another_var = "world";
+                //
+                // html! { <div>{some_var}</div> }  -> would not get a " " inserted
+                //
+                // html! { <div> {some_var}</div> } -> would get a " " inserted
+                if stmt_idx == 0 && !last_tag_kind_was_text && !last_tag_kind_was_brace {
+                    if let Some(open_tag_end) = open_tag_end {
+                        if open_tag_end.0 != brace_span.start().line
+                            || brace_span.start().column - open_tag_end.1 > 1
+                        {
+                            // FIXME BEFORE MERGE: Add a method to generate a new node that
+                            // increments our node_idx. Pass a span to that method
+                            let node_name = format!("node_{}", node_idx);
+                            let node_name = Ident::new(node_name.as_str(), brace_span.clone());
+
+                            let space = quote! {
+                                let #node_name: IterableNodes = VirtualNode::text(" ").into();
+                            };
+                            tokens.push(space);
+
+                            // TODO BEFORE MERGE: Exact same code repeated below. Normalize
+
+                            let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
+
+                            parent_to_children
+                                .get_mut(&parent_idx)
+                                .expect("Parent of this text node")
+                                .push(*node_idx);
+                            node_order.push(*node_idx);
+
+                            *node_idx += 1;
+                        }
+                    }
+                }
+
                 // Here we handle a block being a descendant within some html! call.
                 //
                 // The descendant should implement Into<IterableNodes>
                 //
                 // html { <div> { some_node } </div> }
 
-                let node_name = format!("node_{}", idx);
+                let node_name = format!("node_{}", node_idx);
                 let node_name = Ident::new(node_name.as_str(), stmt.span());
 
                 let nodes = quote! {
@@ -37,16 +142,44 @@ impl HtmlParser {
                 };
                 tokens.push(nodes);
 
+                // TODO BEFORE MERGE: Exact same code repeated above. Normalize
+
                 let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
 
                 parent_to_children
                     .get_mut(&parent_idx)
                     .expect("Parent of this text node")
-                    .push(*idx);
-                node_order.push(*idx);
+                    .push(*node_idx);
+                node_order.push(*node_idx);
 
-                *idx += 1;
+                *node_idx += 1;
+
+                if should_insert_space_after {
+                    // FIXME BEFORE MERGE: Add a method to generate a new node that
+                    // increments our node_idx. Pass a span to that method
+                    let node_name = format!("node_{}", node_idx);
+                    let node_name = Ident::new(node_name.as_str(), brace_span.clone());
+
+                    let space = quote! {
+                        let #node_name: IterableNodes = VirtualNode::text(" ").into();
+                    };
+                    tokens.push(space);
+
+                    // TODO BEFORE MERGE: Exact same code repeated below. Normalize
+
+                    let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
+
+                    parent_to_children
+                        .get_mut(&parent_idx)
+                        .expect("Parent of this text node")
+                        .push(*node_idx);
+                    node_order.push(*node_idx);
+
+                    *node_idx += 1;
+                }
             }
-        })
+        });
+
+        self.set_most_recent_block_start(brace_span);
     }
 }

--- a/crates/html-macro/src/parser/braced.rs
+++ b/crates/html-macro/src/parser/braced.rs
@@ -101,7 +101,7 @@ impl HtmlParser {
                 if stmt_idx == 0 && !last_tag_kind_was_text && !last_tag_kind_was_brace {
                     if let Some(open_tag_end) = open_tag_end {
                         if open_tag_end.0 != brace_span.start().line
-                            || brace_span.start().column - open_tag_end.1 > 1
+                            || brace_span.start().column - open_tag_end.1 > 0
                         {
                             // FIXME BEFORE MERGE: Add a method to generate a new node that
                             // increments our node_idx. Pass a span to that method

--- a/crates/html-macro/src/parser/braced.rs
+++ b/crates/html-macro/src/parser/braced.rs
@@ -40,14 +40,6 @@ impl HtmlParser {
             _ => false,
         };
 
-        // We ignore this check if the last tag kind was text since the text
-        // parser will already handle inserting spaces before and after text.
-        let last_tag_kind_was_text = self.last_tag_kind == Some(TagKind::Text);
-
-        // We ignore this check if the last tag kind was brace since the previous brace
-        // parser will already handle inserting spaces before this current brace if needed.
-        let last_tag_kind_was_brace = self.last_tag_kind == Some(TagKind::Braced);
-
         // TODO: Only allow one statement per block. Put a quote_spanned! compiler error if
         // there is more than 1 statement. Add a UI test for this.
         block.stmts.iter().for_each(|stmt| {

--- a/crates/html-macro/src/parser/close_tag.rs
+++ b/crates/html-macro/src/parser/close_tag.rs
@@ -1,10 +1,17 @@
 use crate::parser::{is_self_closing, HtmlParser};
-use proc_macro2::Ident;
-use quote::quote_spanned;
+use crate::tag::TagKind;
+use proc_macro2::{Ident, Span};
+use quote::{quote, quote_spanned};
 
 impl HtmlParser {
     /// Parse an incoming Tag::Close
-    pub(crate) fn parse_close_tag(&mut self, name: Ident) {
+    pub(crate) fn parse_close_tag(&mut self, name: &Ident, first_angle_bracket_span: &Span) {
+        let node_idx = &mut self.current_node_idx;
+        let parent_to_children = &mut self.parent_to_children;
+        let parent_stack = &mut self.parent_stack;
+        let tokens = &mut self.tokens;
+        let node_order = &mut self.node_order;
+
         let parent_stack = &mut self.parent_stack;
         let tokens = &mut self.tokens;
 

--- a/crates/html-macro/src/parser/close_tag.rs
+++ b/crates/html-macro/src/parser/close_tag.rs
@@ -1,11 +1,10 @@
 use crate::parser::{is_self_closing, HtmlParser};
-use crate::tag::TagKind;
-use proc_macro2::{Ident, Span};
-use quote::{quote, quote_spanned};
+use proc_macro2::Ident;
+use quote::quote_spanned;
 
 impl HtmlParser {
     /// Parse an incoming Tag::Close
-    pub(crate) fn parse_close_tag(&mut self, name: &Ident, first_angle_bracket_span: &Span) {
+    pub(crate) fn parse_close_tag(&mut self, name: &Ident) {
         let parent_stack = &mut self.parent_stack;
 
         let close_span = name.span();

--- a/crates/html-macro/src/parser/close_tag.rs
+++ b/crates/html-macro/src/parser/close_tag.rs
@@ -6,14 +6,7 @@ use quote::{quote, quote_spanned};
 impl HtmlParser {
     /// Parse an incoming Tag::Close
     pub(crate) fn parse_close_tag(&mut self, name: &Ident, first_angle_bracket_span: &Span) {
-        let node_idx = &mut self.current_node_idx;
-        let parent_to_children = &mut self.parent_to_children;
         let parent_stack = &mut self.parent_stack;
-        let tokens = &mut self.tokens;
-        let node_order = &mut self.node_order;
-
-        let parent_stack = &mut self.parent_stack;
-        let tokens = &mut self.tokens;
 
         let close_span = name.span();
         let close_tag = name.to_string();
@@ -28,18 +21,18 @@ impl HtmlParser {
                 compile_error!(#error);
             }};
 
-            tokens.push(error);
+            self.push_tokens(error);
             return;
         }
 
         let last_open_tag = parent_stack.pop().expect("Last open tag");
 
-        // TODO: join open and close span. Need to figure out how to enable that.
-        //                let open_span = last_open_tag.1.span();
-
         let last_open_tag = last_open_tag.1.to_string();
 
-        // if div != strong
+        // TODO: 2 compile_error!'s one pointing tot he open tag and one pointing to the
+        // closing tag. Update the ui test accordingly
+        //
+        // ex: if div != strong
         if last_open_tag != close_tag {
             let error = format!(
                 r#"Wrong closing tag. Try changing "{}" into "{}""#,
@@ -51,7 +44,7 @@ impl HtmlParser {
             }};
             // TODO: Abort early if we find an error. So we should be returning
             // a Result.
-            tokens.push(error);
+            self.push_tokens(error);
         }
     }
 }

--- a/crates/html-macro/src/parser/close_tag.rs
+++ b/crates/html-macro/src/parser/close_tag.rs
@@ -28,7 +28,7 @@ impl HtmlParser {
 
         let last_open_tag = last_open_tag.1.to_string();
 
-        // TODO: 2 compile_error!'s one pointing tot he open tag and one pointing to the
+        // TODO: 2 compile_error!'s one pointing to the open tag and one pointing to the
         // closing tag. Update the ui test accordingly
         //
         // ex: if div != strong

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -67,7 +67,7 @@ impl HtmlParser {
                 attrs,
                 closing_bracket_span,
             } => {
-                self.parse_open_tag(name, attrs);
+                self.parse_open_tag(name, closing_bracket_span, attrs);
                 self.last_tag_kind = Some(TagKind::Open);
             }
             Tag::Close {

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -11,7 +11,9 @@ mod close_tag;
 mod open_tag;
 mod text;
 
-/// Iterate over Tag's that we've parsed and build a tree of VirtualNode's
+/// Used to parse [Tag]'s that we've parsed and build a tree of VirtualNode's
+///
+/// [Tag]: enum.Tag.html
 pub struct HtmlParser {
     /// As we parse our macro tokens we'll generate new tokens to return back into the compiler
     /// when we're done.
@@ -155,6 +157,22 @@ impl HtmlParser {
     fn set_most_recent_block_start(&mut self, span: &Span) {
         self.recent_span_locations.most_recent_block_start = Some(span.start());
         self.recent_span_locations.most_recent_block_end = Some(span.end());
+    }
+
+    /// Determine whether or not there is any space between the end of the first
+    /// span and the beginning of the second span.
+    ///
+    /// There is space if they are on separate lines or if they have different columns.
+    ///
+    /// html! { <div>Hello</div> } <--- no space between end of div and Hello
+    ///
+    /// html! { <div> Hello</div> } <--- space between end of div and Hello
+    fn separated_by_whitespace(&self, first_span: &Span, second_span: &Span) -> bool {
+        if first_span.end().line != second_span.end().line {
+            return true;
+        }
+
+        second_span.start().column - first_span.end().column > 0
     }
 }
 

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -11,7 +11,7 @@ mod close_tag;
 mod open_tag;
 mod text;
 
-/// Used to parse [Tag]'s that we've parsed and build a tree of VirtualNode's
+/// Used to parse [`Tag`]s that we've parsed and build a tree of `VirtualNode`s
 ///
 /// [Tag]: enum.Tag.html
 pub struct HtmlParser {

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -13,7 +13,7 @@ mod text;
 
 /// Used to parse [`Tag`]s that we've parsed and build a tree of `VirtualNode`s
 ///
-/// [Tag]: enum.Tag.html
+/// [`Tag`]: enum.Tag.html
 pub struct HtmlParser {
     /// As we parse our macro tokens we'll generate new tokens to return back into the compiler
     /// when we're done.

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -1,6 +1,5 @@
 use crate::tag::TagKind;
 use crate::Tag;
-use proc_macro2::{LineColumn, TokenStream};
 use quote::{quote, quote_spanned};
 use std::collections::HashMap;
 use syn::export::Span;
@@ -74,11 +73,8 @@ impl HtmlParser {
                 self.parse_open_tag(name, closing_bracket_span, attrs);
                 self.last_tag_kind = Some(TagKind::Open);
             }
-            Tag::Close {
-                name,
-                first_angle_bracket_span,
-            } => {
-                self.parse_close_tag(name, first_angle_bracket_span);
+            Tag::Close { name, .. } => {
+                self.parse_close_tag(name);
                 self.last_tag_kind = Some(TagKind::Close);
             }
             Tag::Text {

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -193,7 +193,13 @@ impl HtmlParser {
     ///
     /// It will be assigned to the current parent node (whatever the last Tag::Open was)
     ///
-    /// TODO: Nearly identical with push_iterable_nodes. Make them call some DRY function
+    /// FIXME: Stop doing this! Instead of inserting text nodes just check how much white space
+    /// is between the block and the tag before it as well as the block and the tag after it.
+    /// Then, insert quote! tokens that take a mutable reference to the first element in the
+    /// iterable nodes and adds spacing / new lines before it if it is a VText variant.
+    /// Then take a mutable reference to the last element in the iterable nodes and add
+    /// spacing after it if it is a VText variant. Add methods to IterableNodes to easily
+    /// get an optional reference to the first or last element.
     fn push_virtual_text_space_tokens(&mut self, span: Span) {
         let node_idx = self.current_node_idx;
 
@@ -219,8 +225,6 @@ impl HtmlParser {
     ///
     /// html! { <div> { some_var_in_braces } </div>
     /// html! { <div> { some_other_variable } </div>
-    ///
-    /// TODO: Nearly identical with push_virtual_node_space_tokens. Make them call some DRY function
     fn push_iterable_nodes(&mut self, stmt: &Stmt) {
         let node_idx = self.current_node_idx;
         let node_ident = self.new_virtual_node_ident(stmt.span());

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -69,6 +69,7 @@ impl HtmlParser {
                 name,
                 attrs,
                 closing_bracket_span,
+                ..
             } => {
                 self.parse_open_tag(name, closing_bracket_span, attrs);
                 self.last_tag_kind = Some(TagKind::Open);

--- a/crates/html-macro/src/parser/open_tag.rs
+++ b/crates/html-macro/src/parser/open_tag.rs
@@ -33,7 +33,7 @@ impl HtmlParser {
                 Expr::Closure(closure) => {
                     // TODO: Use this to decide Box<FnMut(_, _, _, ...)
                     // After we merge the DomUpdater
-                    let arg_count = closure.inputs.len();
+                    let _arg_count = closure.inputs.len();
 
                     let add_closure = quote! {
                         #[cfg(target_arch = "wasm32")]

--- a/crates/html-macro/src/parser/open_tag.rs
+++ b/crates/html-macro/src/parser/open_tag.rs
@@ -1,13 +1,13 @@
 use crate::parser::{is_self_closing, HtmlParser};
 use crate::tag::Attr;
-use proc_macro2::Ident;
+use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::Expr;
 
 impl HtmlParser {
     /// Parse an incoming Tag::Open
-    pub(crate) fn parse_open_tag(&mut self, name: &Ident, attrs: &Vec<Attr>) {
-        self.set_most_recent_open_tag_end(&name.span());
+    pub(crate) fn parse_open_tag(&mut self, name: &Ident, closing_span: &Span, attrs: &Vec<Attr>) {
+        self.set_most_recent_open_tag_end(closing_span);
 
         let idx = &mut self.current_node_idx;
         let parent_to_children = &mut self.parent_to_children;

--- a/crates/html-macro/src/parser/open_tag.rs
+++ b/crates/html-macro/src/parser/open_tag.rs
@@ -6,8 +6,10 @@ use syn::Expr;
 
 impl HtmlParser {
     /// Parse an incoming Tag::Open
-    pub(crate) fn parse_open_tag(&mut self, name: Ident, attrs: Vec<Attr>) {
-        let idx = &mut self.current_idx;
+    pub(crate) fn parse_open_tag(&mut self, name: &Ident, attrs: &Vec<Attr>) {
+        self.set_most_recent_open_tag_end(&name.span());
+
+        let idx = &mut self.current_node_idx;
         let parent_to_children = &mut self.parent_to_children;
         let parent_stack = &mut self.parent_stack;
         let tokens = &mut self.tokens;
@@ -63,7 +65,7 @@ impl HtmlParser {
             node_order.push(0);
 
             if !is_self_closing(&html_tag) {
-                parent_stack.push((0, name));
+                parent_stack.push((0, name.clone()));
             }
 
             *idx += 1;
@@ -73,7 +75,7 @@ impl HtmlParser {
         let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
 
         if !is_self_closing(&html_tag) {
-            parent_stack.push((*idx, name));
+            parent_stack.push((*idx, name.clone()));
         }
         node_order.push(*idx);
 

--- a/crates/html-macro/src/parser/open_tag.rs
+++ b/crates/html-macro/src/parser/open_tag.rs
@@ -7,7 +7,7 @@ use syn::Expr;
 impl HtmlParser {
     /// Parse an incoming Tag::Open
     pub(crate) fn parse_open_tag(&mut self, name: &Ident, closing_span: &Span, attrs: &Vec<Attr>) {
-        self.set_most_recent_open_tag_end(closing_span);
+        self.set_most_recent_open_tag_end(closing_span.clone());
 
         let idx = &mut self.current_node_idx;
         let parent_to_children = &mut self.parent_to_children;

--- a/crates/html-macro/src/parser/text.rs
+++ b/crates/html-macro/src/parser/text.rs
@@ -2,7 +2,6 @@ use crate::parser::HtmlParser;
 use crate::tag::{Tag, TagKind};
 use proc_macro2::{Ident, Span};
 use quote::quote;
-use std::cmp::max;
 
 impl HtmlParser {
     /// Parse an incoming Tag::Text text node

--- a/crates/html-macro/src/parser/text.rs
+++ b/crates/html-macro/src/parser/text.rs
@@ -27,6 +27,9 @@ impl HtmlParser {
             Some(Tag::Braced { brace_span, .. }) => {
                 self.separated_by_whitespace(&text_end, brace_span)
             }
+            Some(Tag::Open {
+                open_bracket_span, ..
+            }) => self.separated_by_whitespace(&text_end, open_bracket_span),
             _ => false,
         };
         if should_insert_space_after_text {

--- a/crates/html-macro/src/parser/text.rs
+++ b/crates/html-macro/src/parser/text.rs
@@ -1,11 +1,39 @@
 use crate::parser::HtmlParser;
+use crate::tag::Tag;
 use proc_macro2::{Ident, Span};
 use quote::quote;
+use std::cmp::max;
 
 impl HtmlParser {
     /// Parse an incoming Tag::Text text node
-    pub(crate) fn parse_text(&mut self, text: String) {
-        let idx = &mut self.current_idx;
+    pub(crate) fn parse_text(
+        &mut self,
+        text: &str,
+        text_start: Span,
+        text_end: Span,
+        next_tag: Option<&Tag>,
+    ) {
+        let mut text = text.to_string();
+
+        if self.should_insert_space_before_text(&text_start) {
+            text = " ".to_string() + &text;
+        }
+
+        let should_insert_space_after_text = match next_tag {
+            Some(Tag::Close {
+                first_angle_bracket_span,
+                ..
+            }) => self.should_insert_space_after_text(&text_end, first_angle_bracket_span, true),
+            Some(Tag::Braced { brace_span, .. }) => {
+                self.should_insert_space_after_text(&text_end, brace_span, false)
+            }
+            _ => false,
+        };
+        if should_insert_space_after_text {
+            text += " ";
+        }
+
+        let idx = &mut self.current_node_idx;
         let parent_to_children = &mut self.parent_to_children;
         let parent_stack = &mut self.parent_stack;
         let tokens = &mut self.tokens;
@@ -20,7 +48,6 @@ impl HtmlParser {
             parent_stack.push((0, Ident::new("unused", Span::call_site())));
         }
 
-        // TODO: Figure out how to use spans
         let var_name = Ident::new(format!("node_{}", idx).as_str(), Span::call_site());
 
         let text_node = quote! {
@@ -44,5 +71,49 @@ impl HtmlParser {
             .push(*idx);
 
         *idx += 1;
+    }
+
+    fn should_insert_space_before_text(&self, start_span: &Span) -> bool {
+        // If the first thing that we encounter in our HTML macro is test we don't
+        // need to insert any space before it.
+        if self
+            .recent_span_locations
+            .most_recent_open_tag_end
+            .is_none()
+            && self.recent_span_locations.most_recent_block_start.is_none()
+        {
+            return false;
+        }
+
+        let most_recent_open_tag_end = self
+            .recent_span_locations
+            .most_recent_open_tag_end
+            .as_ref()
+            .unwrap();
+
+        return start_span.start().line != most_recent_open_tag_end.line
+            || start_span.start().column - most_recent_open_tag_end.column > 1;
+    }
+
+    fn should_insert_space_after_text(
+        &self,
+        text_end: &Span,
+        next_span: &Span,
+        adjust_span_rustc_bug: bool,
+    ) -> bool {
+        if text_end.end().line != next_span.start().line {
+            return true;
+        }
+
+        if adjust_span_rustc_bug {
+            // TODO: The angle bracket has an incorrect span that has a column that is
+            // one less than what it's supposed to be so we use the token after the span
+            // instead. We can use the angle bracket again after rust-lang/rust #58958
+            // https://github.com/rust-lang/rust/issues/58958
+            // Once the issue closes we can delete this if and keep the else clause
+            return next_span.start().column - text_end.end().column > 0;
+        } else {
+            return next_span.start().column - text_end.end().column > 1;
+        }
     }
 }

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -15,6 +15,7 @@ pub enum Tag {
     Open {
         name: Ident,
         attrs: Vec<Attr>,
+        open_bracket_span: Span,
         closing_bracket_span: Span,
     },
     /// </div>
@@ -87,7 +88,7 @@ impl Parse for Tag {
             let is_open_tag = optional_close.is_none();
 
             if is_open_tag {
-                return parse_open_tag(&mut input);
+                return parse_open_tag(&mut input, first_angle_bracket_span);
             } else {
                 return parse_close_tag(&mut input, first_angle_bracket_span);
             }
@@ -103,7 +104,7 @@ impl Parse for Tag {
 }
 
 /// `<div id="app" class=*CSS>`
-fn parse_open_tag(input: &mut ParseStream) -> Result<Tag> {
+fn parse_open_tag(input: &mut ParseStream, open_bracket_span: Span) -> Result<Tag> {
     let name: Ident = input.parse()?;
 
     let attrs = parse_attributes(input)?;
@@ -117,6 +118,7 @@ fn parse_open_tag(input: &mut ParseStream) -> Result<Tag> {
     Ok(Tag::Open {
         name,
         attrs,
+        open_bracket_span,
         closing_bracket_span,
     })
 }

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -237,9 +237,8 @@ fn parse_text_node(input: &mut ParseStream) -> Result<Tag> {
             most_recent_span = Some(tt.span());
         }
 
-        // Insert necessary space in between the tokens in this text node that we're building.
-        // In the real browser DOM there's no difference between one space and many,
-        // so we just insert one.
+        // TODO: Properly handle whitespace and new lines
+        // https://github.com/chinedufn/percy/pull/97#discussion_r263039215
         if idx != 0 {
             if let Some(most_recent_span) = most_recent_span {
                 let current_span_start = tt.span().start();

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -1,5 +1,4 @@
 use proc_macro2::{Span, TokenStream, TokenTree};
-use std::thread::current;
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
 use syn::token::Brace;

--- a/crates/router-rs-macro-test/src/book_example.rs
+++ b/crates/router-rs-macro-test/src/book_example.rs
@@ -29,9 +29,7 @@ fn provided_data_and_param() {
             .view("/users/10/favorite-meal/breakfast")
             .unwrap()
             .to_string(),
-        // TODO: This is a bug with our text implementation. Will fix...
-        // We want this to be <div> User 10 loves breakfast </div>
-        "<div>User10lovesBreakfast</div>"
+        "<div> User 10 loves Breakfast </div>"
     );
 }
 

--- a/crates/virtual-dom-rs/CHANGELOG.md
+++ b/crates/virtual-dom-rs/CHANGELOG.md
@@ -13,7 +13,7 @@ Types of changes:
 
 _Here we list notable things that have been merged into the master branch but have not been released yet._
 
-- ...
+- [fixed] Proper spacing in between text nodes and elements in all cases [PR](TODO: Link here)
 
 ## 0.6.5 - Mar 4, 2019
 

--- a/crates/virtual-dom-rs/Cargo.toml
+++ b/crates/virtual-dom-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtual-dom-rs"
-version = "0.6.5"
+version = "0.6.6"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 description = "A standalone Virtual DOM creation, diffing and patching implementation"
 keywords = ["virtual", "dom", "wasm", "assembly", "webassembly"]

--- a/examples/unit-testing-components/src/main.rs
+++ b/examples/unit-testing-components/src/main.rs
@@ -57,11 +57,12 @@ mod tests {
 
         let water_view = water_bottle_view(0.2587);
 
+        // FIXME: Change this back to one after handling our whitespace issue
         assert_eq!(
             water_view
                 .as_velement_ref()
                 .expect("Not an element node")
-                .children[0]
+                .children[1]
                 .as_vtext_ref()
                 .expect("Not a text node")
                 .text,


### PR DESCRIPTION
Fixes #83 

Also refactors a good chunk of the `html-macro` to make it easier to read and a good bit more DRY