### PR TITLE
WIP: Comments

### DIFF
--- a/crates/virtual-dom-rs/src/diff/mod.rs
+++ b/crates/virtual-dom-rs/src/diff/mod.rs
@@ -62,6 +62,13 @@ fn diff_recursive<'a, 'b>(
             }
         }
 
+        // We're comparing two comment nodes
+        (VirtualNode::Comment(old_comment), VirtualNode::Comment(new_comment)) => {
+            if old_comment != new_comment {
+                patches.push(Patch::ChangeComment(*cur_node_idx, &new_comment));
+            }
+        }
+
         // We're comparing two element nodes
         (VirtualNode::Element(old_element), VirtualNode::Element(new_element)) => {
             let mut add_attributes: HashMap<&str, &str> = HashMap::new();
@@ -132,8 +139,12 @@ fn diff_recursive<'a, 'b>(
                 }
             }
         }
-        (VirtualNode::Text(_), VirtualNode::Element(_))
-        | (VirtualNode::Element(_), VirtualNode::Text(_)) => {
+        (VirtualNode::Text(_), VirtualNode::Element(_)) |
+        (VirtualNode::Text(_), VirtualNode::Comment(_)) |
+        (VirtualNode::Comment(_), VirtualNode::Element(_)) |
+        (VirtualNode::Comment(_), VirtualNode::Text(_)) |
+        (VirtualNode::Element(_), VirtualNode::Text(_)) |
+        (VirtualNode::Element(_), VirtualNode::Comment(_)) => {
             unreachable!("Unequal variant discriminants should already have been handled");
         }
     };

--- a/crates/virtual-dom-rs/src/patch/mod.rs
+++ b/crates/virtual-dom-rs/src/patch/mod.rs
@@ -1,7 +1,7 @@
 //! Our Patch enum is intentionally kept in it's own file for easy inclusion into
 //! The Percy Book.
 
-use crate::{VText, VirtualNode};
+use crate::{VText, VComment, VirtualNode};
 use std::collections::HashMap;
 
 mod apply_patches;
@@ -55,6 +55,8 @@ pub enum Patch<'a> {
     RemoveAttributes(NodeIdx, Vec<&'a str>),
     /// Change the text of a Text node.
     ChangeText(NodeIdx, &'a VText),
+    /// Change the text of a Comment node.
+    ChangeComment(NodeIdx, &'a VComment),
 }
 
 type NodeIdx = usize;
@@ -71,6 +73,7 @@ impl<'a> Patch<'a> {
             Patch::AddAttributes(node_idx, _) => *node_idx,
             Patch::RemoveAttributes(node_idx, _) => *node_idx,
             Patch::ChangeText(node_idx, _) => *node_idx,
+            Patch::ChangeComment(node_idx, _) => *node_idx,
         }
     }
 }

--- a/crates/virtual-node/src/virtual_node_test_utils.rs
+++ b/crates/virtual-node/src/virtual_node_test_utils.rs
@@ -1,6 +1,6 @@
 //! A collection of functions that are useful for unit testing your html! views.
 
-use crate::{VElement, VirtualNode};
+use crate::VirtualNode;
 
 impl VirtualNode {
     /// Get a vector of all of the VirtualNode children / grandchildren / etc of
@@ -32,6 +32,7 @@ impl VirtualNode {
         let mut descendants: Vec<&'a VirtualNode> = vec![];
         match self {
             VirtualNode::Text(_) => { /* nothing to do */ }
+            VirtualNode::Comment(_) => { /* nothing to do */ }
             VirtualNode::Element(element_node) => {
                 for child in element_node.children.iter() {
                     get_descendants(&mut descendants, child);
@@ -44,6 +45,7 @@ impl VirtualNode {
             .into_iter()
             .filter(|vn: &&'a VirtualNode| match vn {
                 VirtualNode::Text(_) => false,
+                VirtualNode::Comment(_) => false,
                 VirtualNode::Element(element_node) => match element_node.attrs.get("label") {
                     Some(label) => filter(label),
                     None => false,
@@ -80,6 +82,7 @@ fn get_descendants<'a>(descendants: &mut Vec<&'a VirtualNode>, node: &'a Virtual
     descendants.push(node);
     match node {
         VirtualNode::Text(_) => { /* nothing to do */ }
+        VirtualNode::Comment(_) => { /* nothing to do */ }
         VirtualNode::Element(element_node) => {
             for child in element_node.children.iter() {
                 get_descendants(descendants, child);


### PR DESCRIPTION
Initial draft for adding user defined comment support.

Most of it was straightforward, although some parts should probably be refactored in the future since it's getting boilerplate-y.

The main open question I'm facing right now is in `crates/virtual-dom-rs/src/patch/apply_patches.rs`:

            Node::COMMENT_NODE => {
                // At this time we do not support user entered comment nodes, so if we see a comment
                // then it was a delimiter created by virtual-dom-rs in order to ensure that two
                // neighboring text nodes did not get merged into one by the browser. So we skip
                // over this virtual-dom-rs generated comment node.
            }

How do we deal with the `<!-- ptns -->` comments?