### PR TITLE
Download example

### DIFF
--- a/examples/isomorphic/app/Cargo.toml
+++ b/examples/isomorphic/app/Cargo.toml
@@ -11,5 +11,6 @@ router-rs = { path = "../../../crates/router-rs"}
 log = "0.4.6"
 serde = { version = "1", features = ["rc", "derive"] }
 serde_json = "1"
-wasm-bindgen = "0.2.33"
+wasm-bindgen = { version = "0.2.33", features = ["serde-serialize"] }
 web-sys = "0.3.10"
+js-sys = "0.3.2"

--- a/examples/isomorphic/app/Cargo.toml
+++ b/examples/isomorphic/app/Cargo.toml
@@ -9,8 +9,7 @@ css-rs-macro = { path = "../../../crates/css-rs-macro"}
 virtual-dom-rs = { path = "../../../crates/virtual-dom-rs" }
 router-rs = { path = "../../../crates/router-rs"}
 log = "0.4.6"
-serde = { version = "1", features = ["rc"] }
-serde_derive = "1"
+serde = { version = "1", features = ["rc", "derive"] }
 serde_json = "1"
 wasm-bindgen = "0.2.33"
 web-sys = "0.3.10"

--- a/examples/isomorphic/app/src/lib.rs
+++ b/examples/isomorphic/app/src/lib.rs
@@ -79,7 +79,10 @@ fn download_contributors_json(store: Provided<Rc<RefCell<Store>>>) {
     let callback = Closure::wrap(Box::new(move |json: JsValue| {
         store.borrow_mut().msg(&Msg::StoreContributors(json));
     }) as Box<FnMut(JsValue)>);
-    download_json("https://api.github.com/repos/chinedufn/percy/contributors", callback.as_ref().unchecked_ref());
+    download_json(
+        "https://api.github.com/repos/chinedufn/percy/contributors",
+        callback.as_ref().unchecked_ref(),
+    );
 
     callback.forget();
 }

--- a/examples/isomorphic/app/src/lib.rs
+++ b/examples/isomorphic/app/src/lib.rs
@@ -1,11 +1,5 @@
 #![feature(proc_macro_hygiene)]
 
-#[macro_use]
-extern crate serde_derive;
-
-#[macro_use]
-extern  crate log;
-
 pub use crate::state::*;
 pub use crate::store::*;
 use crate::views::*;
@@ -13,6 +7,7 @@ use router_rs::prelude::*;
 use std::cell::RefCell;
 use std::rc::Rc;
 use virtual_dom_rs::prelude::*;
+use log::info;
 pub use virtual_dom_rs::VirtualNode;
 
 mod state;
@@ -69,7 +64,7 @@ fn contributors_route(store: Provided<Rc<RefCell<Store>>>) -> VirtualNode {
     ContributorsView::new(Rc::clone(&store)).render()
 }
 
-fn download_contributors_json(store: Provided<Rc<RefCell<Store>>>) {
+fn download_contributors_json(_store: Provided<Rc<RefCell<Store>>>) {
     info!(r#"
     TODO: Make XHR request to GitHub to download JSON data for percy contributors.
     Then store this data in state via store.msg

--- a/examples/isomorphic/app/src/lib.rs
+++ b/examples/isomorphic/app/src/lib.rs
@@ -44,6 +44,10 @@ impl App {
 
         store.borrow_mut().set_router(Rc::clone(&router));
 
+        let path = store.borrow().path().clone().to_string();
+
+        store.borrow_mut().msg(&Msg::SetPath(path));
+
         App { store, router }
     }
 }

--- a/examples/isomorphic/app/src/lib.rs
+++ b/examples/isomorphic/app/src/lib.rs
@@ -77,7 +77,7 @@ extern "C" {
 
 fn download_contributors_json(store: Provided<Rc<RefCell<Store>>>) {
     let callback = Closure::wrap(Box::new(move |json: JsValue| {
-        store.borrow_mut().msg(&Msg::StoreContributors(json));
+        store.borrow_mut().msg(&Msg::SetContributorsJson(json));
     }) as Box<FnMut(JsValue)>);
     download_json(
         "https://api.github.com/repos/chinedufn/percy/contributors",

--- a/examples/isomorphic/app/src/state/mod.rs
+++ b/examples/isomorphic/app/src/state/mod.rs
@@ -70,8 +70,10 @@ impl State {
 // Serde ignores fields not in this struct when deserializing
 #[derive(Serialize, Deserialize)]
 pub struct PercyContributor {
-    pub login: String,    // Github username.
-    pub html_url: String, // Github profile URL. E.g. https://github.com/username
+    /// Github username.
+    pub login: String,
+    /// Github profile URL. E.g. https://github.com/username
+    pub html_url: String,
 }
 
 #[cfg(test)]

--- a/examples/isomorphic/app/src/state/mod.rs
+++ b/examples/isomorphic/app/src/state/mod.rs
@@ -79,7 +79,7 @@ mod tests {
 
     #[test]
     fn serialize_deserialize() {
-        let state_json = r#"{"click_count":5,"path":"/"}"#;
+        let state_json = r#"{"click_count":5,"path":"/","contributors":null}"#;
 
         let state = State::from_json(state_json);
 

--- a/examples/isomorphic/app/src/state/mod.rs
+++ b/examples/isomorphic/app/src/state/mod.rs
@@ -11,6 +11,7 @@ pub struct State {
     click_count: Rc<Cell<u32>>,
     path: String,
     contributors: Option<Vec<PercyContributor>>,
+    has_initiated_contributors_download: bool,
 }
 
 impl State {
@@ -19,6 +20,7 @@ impl State {
             path: "/".to_string(),
             click_count: Rc::new(Cell::new(count)),
             contributors: None,
+            has_initiated_contributors_download: false,
         }
     }
 
@@ -40,7 +42,10 @@ impl State {
             Msg::SetPath(path) => self.set_path(path.to_string()),
 	    Msg::SetContributorsJson(json) => {
 		self.contributors = Some(json.into_serde().unwrap());
-	    }
+	    },
+            Msg::InitiatedContributorsDownload => {
+                self.has_initiated_contributors_download = true;
+            }
         };
     }
 
@@ -54,6 +59,10 @@ impl State {
 
     pub fn contributors(&self) -> &Option<Vec<PercyContributor>> {
         &self.contributors
+    }
+
+    pub fn has_initiated_contributors_download(&self) -> &bool {
+        &self.has_initiated_contributors_download
     }
 }
 

--- a/examples/isomorphic/app/src/state/mod.rs
+++ b/examples/isomorphic/app/src/state/mod.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use serde_json;
 use std::cell::Cell;
 use std::rc::Rc;
@@ -9,7 +9,7 @@ pub use self::msg::Msg;
 #[derive(Serialize, Deserialize)]
 pub struct Contributor {
     pub login: String,
-    pub html_url:   String,
+    pub html_url: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -46,7 +46,7 @@ impl State {
             Msg::SetPath(path) => self.set_path(path.to_string()),
             Msg::StoreContributors(json) => {
                 self.contributors = Some(json.into_serde().unwrap());
-            },
+            }
         };
     }
 

--- a/examples/isomorphic/app/src/state/mod.rs
+++ b/examples/isomorphic/app/src/state/mod.rs
@@ -7,16 +7,10 @@ mod msg;
 pub use self::msg::Msg;
 
 #[derive(Serialize, Deserialize)]
-pub struct Contributor {
-    pub login: String,
-    pub html_url: String,
-}
-
-#[derive(Serialize, Deserialize)]
 pub struct State {
     click_count: Rc<Cell<u32>>,
     path: String,
-    contributors: Option<Vec<Contributor>>,
+    contributors: Option<Vec<PercyContributor>>,
 }
 
 impl State {
@@ -44,9 +38,9 @@ impl State {
         match msg {
             Msg::Click => self.increment_click(),
             Msg::SetPath(path) => self.set_path(path.to_string()),
-            Msg::StoreContributors(json) => {
-                self.contributors = Some(json.into_serde().unwrap());
-            }
+	    Msg::SetContributorsJson(json) => {
+		self.contributors = Some(json.into_serde().unwrap());
+	    }
         };
     }
 
@@ -58,7 +52,7 @@ impl State {
         &self.path
     }
 
-    pub fn contributors(&self) -> &Option<Vec<Contributor>> {
+    pub fn contributors(&self) -> &Option<Vec<PercyContributor>> {
         &self.contributors
     }
 }
@@ -71,6 +65,13 @@ impl State {
     fn set_path(&mut self, path: String) {
         self.path = path;
     }
+}
+
+// Serde ignores fields not in this struct when deserializing
+#[derive(Serialize, Deserialize)]
+pub struct PercyContributor {
+    pub login: String,    // Github username.
+    pub html_url: String, // Github profile URL. E.g. https://github.com/username
 }
 
 #[cfg(test)]

--- a/examples/isomorphic/app/src/state/mod.rs
+++ b/examples/isomorphic/app/src/state/mod.rs
@@ -7,9 +7,16 @@ mod msg;
 pub use self::msg::Msg;
 
 #[derive(Serialize, Deserialize)]
+pub struct Contributor {
+    pub login: String,
+    pub html_url:   String,
+}
+
+#[derive(Serialize, Deserialize)]
 pub struct State {
     click_count: Rc<Cell<u32>>,
     path: String,
+    contributors: Option<Vec<Contributor>>,
 }
 
 impl State {
@@ -17,6 +24,7 @@ impl State {
         State {
             path: "/".to_string(),
             click_count: Rc::new(Cell::new(count)),
+            contributors: None,
         }
     }
 
@@ -36,6 +44,9 @@ impl State {
         match msg {
             Msg::Click => self.increment_click(),
             Msg::SetPath(path) => self.set_path(path.to_string()),
+            Msg::StoreContributors(json) => {
+                self.contributors = Some(json.into_serde().unwrap());
+            },
         };
     }
 
@@ -45,6 +56,10 @@ impl State {
 
     pub fn path(&self) -> &str {
         &self.path
+    }
+
+    pub fn contributors(&self) -> &Option<Vec<Contributor>> {
+        &self.contributors
     }
 }
 

--- a/examples/isomorphic/app/src/state/msg.rs
+++ b/examples/isomorphic/app/src/state/msg.rs
@@ -5,4 +5,6 @@ pub enum Msg {
     SetPath(String),
     /// Deserializes JSON array of Github contributors to `Option<Vec<PercyContributor>>`
     SetContributorsJson(JsValue),
+    /// Represents whether the client is already fetching the JSON array of Github contributors
+    InitiatedContributorsDownload,
 }

--- a/examples/isomorphic/app/src/state/msg.rs
+++ b/examples/isomorphic/app/src/state/msg.rs
@@ -1,4 +1,7 @@
+use wasm_bindgen::JsValue;
+
 pub enum Msg {
     Click,
     SetPath(String),
+    StoreContributors(JsValue),
 }

--- a/examples/isomorphic/app/src/state/msg.rs
+++ b/examples/isomorphic/app/src/state/msg.rs
@@ -3,5 +3,7 @@ use wasm_bindgen::JsValue;
 pub enum Msg {
     Click,
     SetPath(String),
-    StoreContributors(JsValue),
+    // Deserializes JSON array of Github contributors
+    // to `Option<Vec<PercyContributor>>`
+    SetContributorsJson(JsValue),
 }

--- a/examples/isomorphic/app/src/state/msg.rs
+++ b/examples/isomorphic/app/src/state/msg.rs
@@ -3,7 +3,6 @@ use wasm_bindgen::JsValue;
 pub enum Msg {
     Click,
     SetPath(String),
-    // Deserializes JSON array of Github contributors
-    // to `Option<Vec<PercyContributor>>`
+    /// Deserializes JSON array of Github contributors to `Option<Vec<PercyContributor>>`
     SetContributorsJson(JsValue),
 }

--- a/examples/isomorphic/app/src/store.rs
+++ b/examples/isomorphic/app/src/store.rs
@@ -36,7 +36,7 @@ impl Store {
                 if let Some(after_route) = &self.after_route {
                     after_route(path.as_str());
                 }
-            }
+            },
             _ => self.state.msg(msg),
         }
 

--- a/examples/isomorphic/app/src/store.rs
+++ b/examples/isomorphic/app/src/store.rs
@@ -1,9 +1,9 @@
 use crate::state::Msg;
 use crate::state::State;
 
+use router_rs::prelude::Router;
 use std::ops::Deref;
 use std::rc::Rc;
-use router_rs::prelude::Router;
 
 pub struct Store {
     state: StateWrapper,

--- a/examples/isomorphic/app/src/store.rs
+++ b/examples/isomorphic/app/src/store.rs
@@ -8,7 +8,8 @@ use router_rs::prelude::Router;
 pub struct Store {
     state: StateWrapper,
     after_route: Option<Box<Fn(&str) -> ()>>,
-    router: Option<Rc<Router>>
+    router: Option<Rc<Router>>,
+    listeners: Vec<Box<Fn() -> ()>>,
 }
 
 impl Store {
@@ -16,7 +17,8 @@ impl Store {
         Store {
             state: StateWrapper(state),
             after_route: None,
-            router: None
+            router: None,
+            listeners: vec![],
         }
     }
 
@@ -37,10 +39,15 @@ impl Store {
             }
             _ => self.state.msg(msg),
         }
+
+        // Whenever we update state we'll let all of our listeners know that state was updated
+        for callback in self.listeners.iter() {
+            callback();
+        }
     }
 
     pub fn subscribe(&mut self, callback: Box<Fn() -> ()>) {
-        self.state.subscribe(callback);
+        self.listeners.push(callback)
     }
 
     pub fn set_after_route(&mut self, after_route: Box<Fn(&str) -> ()>) {
@@ -73,9 +80,5 @@ impl Deref for StateWrapper {
 impl StateWrapper {
     fn msg(&mut self, msg: &Msg) {
         self.0.msg(msg)
-    }
-
-    fn subscribe(&mut self, callback: Box<Fn() -> ()>) {
-        self.0.subscribe(callback);
     }
 }

--- a/examples/isomorphic/app/src/views/contributors_view.rs
+++ b/examples/isomorphic/app/src/views/contributors_view.rs
@@ -18,14 +18,35 @@ impl ContributorsView {
 impl View for ContributorsView {
     fn render(&self) -> VirtualNode {
         let nav_bar = NavBarView::new(ActivePage::Contributors).render();
+        let store = self.store.borrow();
+        let contributors = store.contributors().to_owned();
+        let contributors_list: Vec<VirtualNode> = match contributors {
+                Some(contributors) => contributors.iter()
+                    .filter(|c| c.login != "invalid-email-address".to_string())
+                    .map(|contributor| {
+                        html! {
+                            <li>
+                                <a
+                                    href=contributor.html_url.to_string()
+                                    target="_blank"
+                                >
+                                    { contributor.login.to_string() }
+                                </a>
+                            </li>
+                        }
+                    }).collect(),
+                None => vec![ VirtualNode::text("Loading...") ],
+        };
 
         html! {
-        <div>
-            { nav_bar }
             <div>
-             Contributors page here
+                { nav_bar }
+                <div>
+                    <ul>
+                        { contributors_list }
+                    </ul>
+                </div>
             </div>
-        </div>
         }
     }
 }

--- a/examples/isomorphic/app/src/views/contributors_view.rs
+++ b/examples/isomorphic/app/src/views/contributors_view.rs
@@ -21,21 +21,23 @@ impl View for ContributorsView {
         let store = self.store.borrow();
         let contributors = store.contributors().to_owned();
         let contributors_list: Vec<VirtualNode> = match contributors {
-                Some(contributors) => contributors.iter()
-                    .filter(|c| c.login != "invalid-email-address".to_string())
-                    .map(|contributor| {
-                        html! {
-                            <li>
-                                <a
-                                    href=contributor.html_url.to_string()
-                                    target="_blank"
-                                >
-                                    { contributor.login.to_string() }
-                                </a>
-                            </li>
-                        }
-                    }).collect(),
-                None => vec![ VirtualNode::text("Loading...") ],
+            Some(contributors) => contributors
+                .iter()
+                .filter(|c| c.login != "invalid-email-address".to_string())
+                .map(|contributor| {
+                    html! {
+                        <li>
+                            <a
+                                href=contributor.html_url.to_string()
+                                target="_blank"
+                            >
+                                { contributor.login.to_string() }
+                            </a>
+                        </li>
+                    }
+                })
+                .collect(),
+            None => vec![VirtualNode::text("Loading...")],
         };
 
         html! {

--- a/examples/isomorphic/app/src/views/contributors_view.rs
+++ b/examples/isomorphic/app/src/views/contributors_view.rs
@@ -17,7 +17,7 @@ impl ContributorsView {
 
 impl View for ContributorsView {
     fn render(&self) -> VirtualNode {
-        let nav_bar = NavBarView::new(ActivePage::Contributors, Rc::clone(&self.store)).render();
+        let nav_bar = NavBarView::new(ActivePage::Contributors).render();
 
         html! {
         <div>

--- a/examples/isomorphic/app/src/views/contributors_view.rs
+++ b/examples/isomorphic/app/src/views/contributors_view.rs
@@ -18,6 +18,7 @@ impl ContributorsView {
 impl View for ContributorsView {
     fn render(&self) -> VirtualNode {
         let nav_bar = NavBarView::new(ActivePage::Contributors).render();
+
         let store = self.store.borrow();
         let contributors = store.contributors().to_owned();
         let contributors_list: Vec<VirtualNode> = match contributors {

--- a/examples/isomorphic/app/src/views/home_view.rs
+++ b/examples/isomorphic/app/src/views/home_view.rs
@@ -20,7 +20,7 @@ impl HomeView {
 
 impl View for HomeView {
     fn render(&self) -> VirtualNode {
-        let nav_bar = NavBarView::new(ActivePage::Home, Rc::clone(&self.store)).render();
+        let nav_bar = NavBarView::new(ActivePage::Home).render();
 
         let store = Rc::clone(&self.store);
 

--- a/examples/isomorphic/app/src/views/nav_bar_view/mod.rs
+++ b/examples/isomorphic/app/src/views/nav_bar_view/mod.rs
@@ -22,11 +22,8 @@ pub enum ActivePage {
 impl View for NavBarView {
     fn render(&self) -> VirtualNode {
         let home = NavBarItemView::new("/", "Isomorphic Web App", "");
-        let contributors = NavBarItemView::new(
-            "/contributors",
-            "Contributors",
-            "margin-left: auto;",
-        );
+        let contributors =
+            NavBarItemView::new("/contributors", "Contributors", "margin-left: auto;");
 
         html! {
         <div class=NAV_BAR_CSS>

--- a/examples/isomorphic/app/src/views/nav_bar_view/mod.rs
+++ b/examples/isomorphic/app/src/views/nav_bar_view/mod.rs
@@ -1,7 +1,4 @@
-use crate::store::Store;
 use css_rs_macro::css;
-use std::cell::RefCell;
-use std::rc::Rc;
 use virtual_dom_rs::prelude::*;
 
 mod nav_bar_item_view;
@@ -9,12 +6,11 @@ use self::nav_bar_item_view::NavBarItemView;
 
 pub struct NavBarView {
     active_page: ActivePage,
-    store: Rc<RefCell<Store>>,
 }
 
 impl NavBarView {
-    pub fn new(active_page: ActivePage, store: Rc<RefCell<Store>>) -> NavBarView {
-        NavBarView { active_page, store }
+    pub fn new(active_page: ActivePage) -> NavBarView {
+        NavBarView { active_page }
     }
 }
 
@@ -25,11 +21,8 @@ pub enum ActivePage {
 
 impl View for NavBarView {
     fn render(&self) -> VirtualNode {
-        let store = self.store.borrow();
-
-        let home = NavBarItemView::new(Rc::clone(&self.store), "/", "Isomorphic Web App", "");
+        let home = NavBarItemView::new("/", "Isomorphic Web App", "");
         let contributors = NavBarItemView::new(
-            Rc::clone(&self.store),
             "/contributors",
             "Contributors",
             "margin-left: auto;",

--- a/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
+++ b/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
@@ -1,26 +1,19 @@
-use crate::store::Store;
-use crate::Msg;
 use css_rs_macro::css;
-use std::cell::RefCell;
-use std::rc::Rc;
 use virtual_dom_rs::prelude::*;
 
 pub struct NavBarItemView {
     path: &'static str,
     text: &'static str,
     style: &'static str,
-    store: Rc<RefCell<Store>>,
 }
 
 impl NavBarItemView {
     pub fn new(
-        store: Rc<RefCell<Store>>,
         path: &'static str,
         text: &'static str,
         style: &'static str,
     ) -> NavBarItemView {
         NavBarItemView {
-            store,
             path,
             text,
             style,
@@ -30,19 +23,13 @@ impl NavBarItemView {
 
 impl View for NavBarItemView {
     fn render(&self) -> VirtualNode {
-        let store = Rc::clone(&self.store);
-
-        let path = self.path;
-
-        let text = VirtualNode::text(self.text);
-
         html! {
             <a
              href=self.path
              style=self.style
              class=NAV_BAR_ITEM_CSS
             >
-              { text }
+              { self.text }
             </a>
         }
     }

--- a/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
+++ b/examples/isomorphic/app/src/views/nav_bar_view/nav_bar_item_view.rs
@@ -11,13 +11,9 @@ impl NavBarItemView {
     pub fn new(
         path: &'static str,
         text: &'static str,
-        style: &'static str,
+        style: &'static str
     ) -> NavBarItemView {
-        NavBarItemView {
-            path,
-            text,
-            style,
-        }
+        NavBarItemView { path, text, style }
     }
 }
 

--- a/examples/isomorphic/client/build-wasm.prod.sh
+++ b/examples/isomorphic/client/build-wasm.prod.sh
@@ -5,4 +5,4 @@ cd $(dirname $0)
 rm -rf dist/
 mkdir -p dist/
 
-wasm-pack build --target no-modules --no-typescript --out-dir ./dist --release
+wasm-pack build --target web --no-typescript --out-dir ./dist --release

--- a/examples/isomorphic/client/build-wasm.sh
+++ b/examples/isomorphic/client/build-wasm.sh
@@ -5,4 +5,4 @@ cd $(dirname $0)
 mkdir -p build/
 mkdir -p dist/
 
-wasm-pack build --target no-modules --no-typescript --out-dir ./build
+wasm-pack build --target web --no-typescript --out-dir ./build

--- a/examples/isomorphic/server/src/index.html
+++ b/examples/isomorphic/server/src/index.html
@@ -11,10 +11,7 @@
       #HTML_INSERTED_HERE_BY_SERVER#
   </div>
 
-  <script src='./static/isomorphic_client.js'></script>
-  <script>
-    window.wasm_bindgen(`/static/isomorphic_client_bg.wasm`).then(main)
-
+  <script type=module>
     let client
     let updateScheduled = false
 
@@ -32,13 +29,17 @@
 
       updateScheduled = true
     }
-
     window.global_js = new GlobalJS()
 
-    function main () {
-      const { Client } = window.wasm_bindgen
+    import { Client, default as init } from './static/isomorphic_client.js';
+
+    async function run() {
+      await init('static/isomorphic_client_bg.wasm');
+
       client = new Client(window.initialState)
     }
+
+    run();
   </script>
   <script>
       window.initialState = '#INITIAL_STATE_JSON#'

--- a/examples/isomorphic/server/src/index.html
+++ b/examples/isomorphic/server/src/index.html
@@ -12,8 +12,6 @@
       #HTML_INSERTED_HERE_BY_SERVER#
   </div>
   <script>
-    // TODO: Use web-sys's fetch instead
-    // https://rustwasm.github.io/docs/wasm-bindgen/examples/fetch.html
     function downloadJson(path, callback) {
       fetch(path)
         .then(function(response) {
@@ -44,7 +42,7 @@
     }
     window.global_js = new GlobalJS()
 
-    import { Client, default as init } from './static/isomorphic_client.js';
+    import { Client, default as init } from '/static/isomorphic_client.js';
 
     async function run() {
       await init('static/isomorphic_client_bg.wasm');

--- a/examples/isomorphic/server/src/index.html
+++ b/examples/isomorphic/server/src/index.html
@@ -4,13 +4,26 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" type="text/css" href="/static/app.css"/>
+    <link rel="shortcut icon" href="#" />
     <title>Rust Web App</title>
 </head>
 <body style='margin: 0; padding: 0; width: 100%; height: 100%;'>
   <div id="isomorphic-rust-web-app" style='width: 100%; height: 100%;'>
       #HTML_INSERTED_HERE_BY_SERVER#
   </div>
-
+  <script>
+    // TODO: Use web-sys's fetch instead
+    // https://rustwasm.github.io/docs/wasm-bindgen/examples/fetch.html
+    function downloadJson(path, callback) {
+      fetch(path)
+        .then(function(response) {
+          return response.json();
+        })
+        .then(function(json) {
+            callback(json);
+        });
+    }
+  </script>
   <script type=module>
     let client
     let updateScheduled = false

--- a/examples/isomorphic/server/src/lib.rs
+++ b/examples/isomorphic/server/src/lib.rs
@@ -1,4 +1,1 @@
-extern crate isomorphic_app;
-extern crate virtual_dom_rs;
-
 pub mod server;

--- a/examples/isomorphic/server/src/main.rs
+++ b/examples/isomorphic/server/src/main.rs
@@ -1,9 +1,4 @@
-extern crate isomorphic_app;
-extern crate isomorphic_server;
-
 use isomorphic_server::server;
-use std::env;
-use std::thread::Builder;
 
 fn main() {
     env_logger::init();

--- a/examples/isomorphic/server/src/server.rs
+++ b/examples/isomorphic/server/src/server.rs
@@ -1,5 +1,4 @@
-extern crate actix_web;
-use self::actix_web::{fs, HttpRequest, HttpResponse, Responder};
+use actix_web::{fs, HttpRequest, HttpResponse, Responder};
 
 use isomorphic_app::App;
 


### PR DESCRIPTION
This pull request is to add the feature to download JSON from the Github API for the isomorphic example.
The JSON data holds information about the contributors for the master branch of Percy.

Right now only the client performs the fetch request, but I'd imagine there's a way to have the server perform the same operation before serving the route.  I'm just not completely sure how to go about doing that.

The contributors are stored in an `Option<Vec<Contributor>>` field for `State`.  While `Contributor` holds the login name and html url for each contributor.  Right now the definition for `Contributor` lives in `app/src/state.rs`.