### PR TITLE
Get client wasm file relative to base route rather than current route

### DIFF
--- a/examples/isomorphic/server/src/index.html
+++ b/examples/isomorphic/server/src/index.html
@@ -45,7 +45,7 @@
     import { Client, default as init } from '/static/isomorphic_client.js';
 
     async function run() {
-      await init('static/isomorphic_client_bg.wasm');
+      await init('/static/isomorphic_client_bg.wasm');
 
       client = new Client(window.initialState)
     }


### PR DESCRIPTION
When hard-refreshing against a non-root route in the isomorphic example, the client WASM file's retrieval is attempted relative to the current route rather than the root.

### Example
<img width="1680" alt="Screen Shot 2019-06-02 at 1 15 28 PM" src="https://user-images.githubusercontent.com/708562/58764735-ee0cf480-8538-11e9-94f1-4f9319f374af.png">

`companies/static/client_bg.wasm` should be `static/client_bg.wasm`, which this PR addresses.