### PR TITLE
Single branch if statement in html! macro

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -10,6 +10,7 @@
     - [Compile Time Errors](./html-macro/compile-time-errors.md)
     - [Working with Text](./html-macro/text/README.md)
     - [Setting Inner HTML](./html-macro/setting-inner-html/README.md)
+    - [Conditional Rendering](./html-macro/conditional-rendering/README.md)
     - [Real Elements and Nodes](./html-macro/real-elements-and-nodes/on-create-elem/README.md)
       - [on_create_elem](./html-macro/real-elements-and-nodes/on-create-elem/README.md)
   - [Virtual DOM](./virtual-dom/README.md)

--- a/book/src/html-macro/conditional-rendering/README.md
+++ b/book/src/html-macro/conditional-rendering/README.md
@@ -1,0 +1,24 @@
+# Conditional Rendering
+
+Sometimes you'll want to conditionally render some html without an else statement. This isn't actually possible in Rust
+because an if-else statement is an expression, this means that you can assign this to a variable as the types of the then
+and else branches don't match.
+
+Although this is quite a common practice in React and other web frameworks, and is supported in Percy.
+
+You'll be able to include if statements without an else branch inside the html macro.
+
+```rust
+fn conditional_render() {
+    html! {
+        <div>
+            <h1>Hello World</h1>
+            {if should_show_child() {
+                html! {
+                    <p>This child component will only render if the condition evaluates to true</p>
+                }
+            }}
+        </div>
+    }
+}
+```

--- a/crates/html-macro-test/src/lib.rs
+++ b/crates/html-macro-test/src/lib.rs
@@ -254,3 +254,81 @@ fn self_closing_tag() {
     }
     .test();
 }
+
+#[test]
+fn if_true_block() {
+    let child_valid = html! { <b></b> };
+    let child_invalid = html! { <i></i> };
+
+    let mut expected = VElement::new("div");
+    expected.children = vec![VirtualNode::element("b")];
+
+    HtmlMacroTest {
+        desc: "If true block",
+        generated: html! {
+          <div>
+            {if true {child_valid} else {child_invalid}}
+          </div>
+        },
+        expected: expected.into(),
+    }
+    .test();
+}
+
+#[test]
+fn if_false_block() {
+    let child_valid = html! { <b></b> };
+    let child_invalid = html! { <i></i> };
+
+    let mut expected = VElement::new("div");
+    expected.children = vec![VirtualNode::element("i")];
+
+    HtmlMacroTest {
+        desc: "If false block",
+        generated: html! {
+          <div>
+            {if false {
+                child_valid
+            } else {
+                child_invalid
+            }}
+          </div>
+        },
+        expected: expected.into(),
+    }
+    .test();
+}
+
+#[test]
+fn single_branch_if_true_block() {
+    let child_valid = html! { <b></b> };
+
+    let mut expected = VElement::new("div");
+    expected.children = vec![VirtualNode::element("b")];
+
+    HtmlMacroTest {
+        desc: "Single branch if block block",
+        generated: html! {
+          <div>{if true {child_valid}}</div>
+        },
+        expected: expected.into(),
+    }
+    .test();
+}
+
+#[test]
+fn single_branch_if_false_block() {
+    let child_valid = html! { <b></b> };
+
+    let mut expected = VElement::new("div");
+    expected.children = vec![VirtualNode::text("")];
+
+    HtmlMacroTest {
+        desc: "Single branch if block block",
+        generated: html! {
+          <div>{if false {child_valid}}</div>
+        },
+        expected: expected.into(),
+    }
+    .test();
+}

--- a/crates/html-macro/src/parser/braced.rs
+++ b/crates/html-macro/src/parser/braced.rs
@@ -73,12 +73,7 @@ impl HtmlParser {
                 };
                 self.push_tokens(node);
             } else {
-                // Here we handle a block being a descendant within some html! call.
-                //
-                // The descendant should implement Into<IterableNodes>
-                //
-                // html { <div> { some_node } </div> }
-                self.push_iterable_nodes(stmt);
+                self.parse_statement(stmt);
 
                 if insert_whitespace_before_text {
                     let node = self.current_virtual_node_ident(stmt.span());

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -10,6 +10,7 @@ mod braced;
 mod close_tag;
 mod open_tag;
 mod text;
+mod statement;
 
 /// Used to parse [`Tag`]s that we've parsed and build a tree of `VirtualNode`s
 ///
@@ -207,14 +208,19 @@ impl HtmlParser {
     ///
     /// html! { <div> { some_var_in_braces } </div>
     /// html! { <div> { some_other_variable } </div>
-    fn push_iterable_nodes(&mut self, stmt: &Stmt) {
+    fn push_iterable_nodes(&mut self, stmt: &Stmt, tokens: Option<proc_macro2::TokenStream>) {
         let node_idx = self.current_node_idx;
         let node_ident = self.new_virtual_node_ident(stmt.span());
 
-        let nodes = quote! {
-            let mut #node_ident: IterableNodes = #stmt.into();
-        };
-        self.push_tokens(nodes);
+        if let Some(nodes) = tokens {
+            self.push_tokens(quote! {
+                let mut #node_ident: IterableNodes = #nodes.into();
+            });
+        } else {
+            self.push_tokens(quote! {
+                let mut #node_ident: IterableNodes = #stmt.into();
+            });
+        }
 
         let parent_idx = *&self.parent_stack[self.parent_stack.len() - 1].0;
 

--- a/crates/html-macro/src/parser/statement.rs
+++ b/crates/html-macro/src/parser/statement.rs
@@ -43,13 +43,13 @@ impl HtmlParser {
     /// 
     /// ```rust,ignore
     /// html! {
-    /// 	<div>
-    /// 		{if condition_is_true {
-    ///				html! {
-    /// 				<span>Hello World</span>
-    /// 			}
-    ///			}}
-    /// 	</div>
+    ///     <div>
+    ///         {if condition_is_true {
+    ///	            html! {
+    ///                 <span>Hello World</span>
+    ///             }
+    ///	        }}
+    ///     </div>
     /// }
     /// ```
     /// 

--- a/crates/html-macro/src/parser/statement.rs
+++ b/crates/html-macro/src/parser/statement.rs
@@ -3,80 +3,80 @@ use quote::quote;
 use syn::{Stmt, Expr, ExprIf};
 
 impl HtmlParser {
-	/// Parse an incoming syn::Stmt node inside a block
+    /// Parse an incoming syn::Stmt node inside a block
     pub(crate) fn parse_statement(
         &mut self,
         stmt: &Stmt,
     ) {
-		// Here we handle a block being a descendant within some html! call.
-		//
-		// The descendant should implement Into<IterableNodes>
-		//
-		// html { <div> { some_node } </div> }
-		match stmt {
-			Stmt::Expr(expr) => self.parse_expr(stmt, expr),
-			_ => self.push_iterable_nodes(stmt, None)
-		};
-	}
+        // Here we handle a block being a descendant within some html! call.
+        //
+        // The descendant should implement Into<IterableNodes>
+        //
+        // html { <div> { some_node } </div> }
+        match stmt {
+            Stmt::Expr(expr) => self.parse_expr(stmt, expr),
+            _ => self.push_iterable_nodes(stmt, None)
+        };
+    }
 
-	/// Parse an incoming syn::Expr node inside a block
-	pub(crate) fn parse_expr(
-		&mut self,
-		stmt: &Stmt,
-		expr: &Expr
-	) {
-		match expr {
-			Expr::If(expr_if) => {
-				self.expand_if(stmt, expr_if);
-			},
-			_ => {
-				self.push_iterable_nodes(stmt, None);
-			}
-		}
-	}
+    /// Parse an incoming syn::Expr node inside a block
+    pub(crate) fn parse_expr(
+        &mut self,
+        stmt: &Stmt,
+        expr: &Expr
+    ) {
+        match expr {
+            Expr::If(expr_if) => {
+                self.expand_if(stmt, expr_if);
+            },
+            _ => {
+                self.push_iterable_nodes(stmt, None);
+            }
+        }
+    }
 
-	/// Expand an incoming Expr::If block
-	/// This enables us to use JSX-style conditions inside of blocks such as
-	/// the following example.
-	/// 
-	/// # Examples
-	/// 
-	/// ```rust,ignore
-	/// html! {
-	/// 	<div>
-	/// 		{if condition_is_true {
-	///				html! {
-	/// 				<span>Hello World</span>
-	/// 			}
-	///			}}
-	/// 	</div>
-	/// }
-	/// ```
-	/// 
-	/// Traditionally this would be possible as an if statement in rust is an
-	/// expression, so the then, and the else block have to return matching types.
-	/// Here we identify whether the block is missing the else and fill it in with
-	/// a blank VirtualNode
-	pub(crate) fn expand_if(
-		&mut self,
-		stmt: &Stmt,
-		expr_if: &ExprIf
-	) {
-		// Has else branch, we can parse the expression as normal.
-		if let Some(_else_branch) = &expr_if.else_branch {
-			self.push_iterable_nodes(stmt, None);
-		} else {
-			let condition = &expr_if.cond;
-			let block = &expr_if.then_branch;
-			let new_stmt = quote! {
-				if #condition {
-					#block.into()
-				} else {
-					VirtualNode::text("")
-				}
-			};
+    /// Expand an incoming Expr::If block
+    /// This enables us to use JSX-style conditions inside of blocks such as
+    /// the following example.
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust,ignore
+    /// html! {
+    /// 	<div>
+    /// 		{if condition_is_true {
+    ///				html! {
+    /// 				<span>Hello World</span>
+    /// 			}
+    ///			}}
+    /// 	</div>
+    /// }
+    /// ```
+    /// 
+    /// Traditionally this would be possible as an if statement in rust is an
+    /// expression, so the then, and the else block have to return matching types.
+    /// Here we identify whether the block is missing the else and fill it in with
+    /// a blank VirtualNode
+    pub(crate) fn expand_if(
+        &mut self,
+        stmt: &Stmt,
+        expr_if: &ExprIf
+    ) {
+        // Has else branch, we can parse the expression as normal.
+        if let Some(_else_branch) = &expr_if.else_branch {
+            self.push_iterable_nodes(stmt, None);
+        } else {
+            let condition = &expr_if.cond;
+            let block = &expr_if.then_branch;
+            let new_stmt = quote! {
+                if #condition {
+                    #block.into()
+                } else {
+                    VirtualNode::text("")
+                }
+            };
 
-			self.push_iterable_nodes(stmt, Some(new_stmt));
-		}
-	}
+            self.push_iterable_nodes(stmt, Some(new_stmt));
+        }
+    }
 }

--- a/crates/html-macro/src/parser/statement.rs
+++ b/crates/html-macro/src/parser/statement.rs
@@ -1,0 +1,82 @@
+use crate::parser::HtmlParser;
+use quote::quote;
+use syn::{Stmt, Expr, ExprIf};
+
+impl HtmlParser {
+	/// Parse an incoming syn::Stmt node inside a block
+    pub(crate) fn parse_statement(
+        &mut self,
+        stmt: &Stmt,
+    ) {
+		// Here we handle a block being a descendant within some html! call.
+		//
+		// The descendant should implement Into<IterableNodes>
+		//
+		// html { <div> { some_node } </div> }
+		match stmt {
+			Stmt::Expr(expr) => self.parse_expr(stmt, expr),
+			_ => self.push_iterable_nodes(stmt, None)
+		};
+	}
+
+	/// Parse an incoming syn::Expr node inside a block
+	pub(crate) fn parse_expr(
+		&mut self,
+		stmt: &Stmt,
+		expr: &Expr
+	) {
+		match expr {
+			Expr::If(expr_if) => {
+				self.expand_if(stmt, expr_if);
+			},
+			_ => {
+				self.push_iterable_nodes(stmt, None);
+			}
+		}
+	}
+
+	/// Expand an incoming Expr::If block
+	/// This enables us to use JSX-style conditions inside of blocks such as
+	/// the following example.
+	/// 
+	/// # Examples
+	/// 
+	/// ```rust,ignore
+	/// html! {
+	/// 	<div>
+	/// 		{if condition_is_true {
+	///				html! {
+	/// 				<span>Hello World</span>
+	/// 			}
+	///			}}
+	/// 	</div>
+	/// }
+	/// ```
+	/// 
+	/// Traditionally this would be possible as an if statement in rust is an
+	/// expression, so the then, and the else block have to return matching types.
+	/// Here we identify whether the block is missing the else and fill it in with
+	/// a blank VirtualNode
+	pub(crate) fn expand_if(
+		&mut self,
+		stmt: &Stmt,
+		expr_if: &ExprIf
+	) {
+		// Has else branch, we can parse the expression as normal.
+		if let Some(_else_branch) = &expr_if.else_branch {
+			self.push_iterable_nodes(stmt, None);
+		} else {
+			let condition = &expr_if.cond;
+			let block = &expr_if.then_branch;
+			let new_stmt = quote! {
+				if #condition {
+					#block.into()
+				} else {
+					VirtualNode::text("")
+				}
+			};
+
+			self.push_iterable_nodes(stmt, Some(new_stmt));
+		}
+	}
+}

--- a/crates/html-macro/src/parser/statement.rs
+++ b/crates/html-macro/src/parser/statement.rs
@@ -45,10 +45,8 @@ impl HtmlParser {
     /// html! {
     ///     <div>
     ///         {if condition_is_true {
-    ///	            html! {
-    ///                 <span>Hello World</span>
-    ///             }
-    ///	        }}
+    ///	            html! { <span>Hello World</span> }
+    ///         }}
     ///     </div>
     /// }
     /// ```


### PR DESCRIPTION
This PR adds single branch if statement capabilities into the html! macro, which is a very common use case in React-like frameworks (generally achieved with `condition && <jsx/>`. See an example below:

```rust
html! {
    <div>
        <h1>A component</h1>
        {if some_condition_is_true {
            html! { <span>Child</span> }
        }}
    </div>
}
```

Currently to do this sort of thing is quite clunky, as if statements are expressions in rust you have to do something like the following which really bloats the components.

```rust
let child = if some_condition_is_true {
    html! { <span>Child</span> }
} else {
    html! { "" }
};

html! {
    <div>
        <h1>A component</h1>
        {child}
    </div>
}
```

I appreciate this is slightly against the grain of rust as you can't do this in traditional rust code however I think it makes sense to include this functionality inside the `html!` macro.

I've added some unit tests for if, else and single branch if statements. I'm pretty new to rust so please let me know if you think anything could be done better. I can also add examples if required, but seems like the tests might cover that.