### PR TITLE
Fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,14 +50,14 @@ jobs:
             && apt-get install -y libgtk-3-0 libdbus-glib-1-2
             # Use an older version of Firefox since newer ones appear to be failing
             # https://github.com/chinedufn/percy/issues/137
-            && wget -q -O - "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
+            && wget "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
             && tar xvf firefox-59.0.2.tar.bz2
             && chmod +x firefox/firefox
 
       # Show versions
       - run:
           name: Show versions
-          command: rustc --version && cargo --version && wasm-pack --version && $(pwd)/firefox/firefox --version
+          command: rustc --version && cargo --version && wasm-pack --version && ./firefox/firefox --version
 
       # Run tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,9 @@ jobs:
           command: >
             apt-get update
             && apt-get install -y libgtk-3-0 libdbus-glib-1-2
-            && wget -q -O - "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US"
+            # Use an older version of Firefox since newer ones appear to be failing
+            # https://github.com/chinedufn/percy/issues/137
+            && wget -q -O - "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
             |  tar xj
 
       # Show versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             # Use an older version of Firefox since newer ones appear to be failing
             # https://github.com/chinedufn/percy/issues/137
             && wget -q -O - "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
-            |  tar xj
+            && tar xvf firefox-59.0.2.tar.bz2
 
       # Show versions
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ jobs:
             && wget "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
             && tar xvf firefox-59.0.2.tar.bz2
             && chmod +x firefox/firefox
+            && pwd && ls
 
       # Show versions
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,17 +48,12 @@ jobs:
           command: >
             apt-get update
             && apt-get install -y libgtk-3-0 libdbus-glib-1-2
-            # Use an older version of Firefox since newer ones appear to be failing. Probably need to apt-get install a few more dependencies
-            # https://github.com/chinedufn/percy/issues/137
-            && wget "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
-            && tar xvf firefox-59.0.2.tar.bz2
-            && chmod +x firefox/firefox
-            && pwd && ls
+            && wget -q -O - "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" |  tar xj
 
       # Show versions
       - run:
           name: Show versions
-          command: pwd && ls && rustc --version && cargo --version && wasm-pack --version && ./firefox/firefox --version
+          command: rustc --version && cargo --version && wasm-pack --version && firefox/firefox --version
 
       # Run tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           command: >
             apt-get update
             && apt-get install -y libgtk-3-0 libdbus-glib-1-2
-            # Use an older version of Firefox since newer ones appear to be failing
+            # Use an older version of Firefox since newer ones appear to be failing. Probably need to apt-get install a few more dependencies
             # https://github.com/chinedufn/percy/issues/137
             && wget "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
             && tar xvf firefox-59.0.2.tar.bz2
@@ -57,7 +57,7 @@ jobs:
       # Show versions
       - run:
           name: Show versions
-          command: rustc --version && cargo --version && wasm-pack --version && ./firefox/firefox --version
+          command: pwd && ls && rustc --version && cargo --version && wasm-pack --version && ./firefox/firefox --version
 
       # Run tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
       # Show versions
       - run:
           name: Show versions
-          command: rustc --version && cargo --version && wasm-pack --version && firefox/firefox --version
+          command: rustc --version && cargo --version && wasm-pack --version && $(pwd)/firefox/firefox --version
 
       # Run tests
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,7 @@ jobs:
             # https://github.com/chinedufn/percy/issues/137
             && wget -q -O - "https://download-installer.cdn.mozilla.net/pub/firefox/releases/59.0.2/linux-x86_64/en-US/firefox-59.0.2.tar.bz2"
             && tar xvf firefox-59.0.2.tar.bz2
+            && chmod +x firefox/firefox
 
       # Show versions
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,76 +2,6 @@ version: 2
 
 jobs:
 
-  test:
-    docker:
-      - image: rust:latest
-    steps:
-      - checkout
-
-      # Load cargo target from cache if possible.
-      # Multiple caches are used to increase the chance of a cache hit.
-      #
-      # Explanation: If you create a new branch, then there won't be a cache
-      # for that branch yet. (The branch is in the name of the cache key to
-      # prevent two branches overwriting each other's caches.)
-      #
-      # However, if you create a new branch, you could still use the latest
-      # cache of any other branch as a starting point. You probably won't be
-      # able to reuse everything, but – as long as cache invalidation works
-      # properly – you'll still be faster than if you don't have any cache
-      # at all.
-      - restore_cache:
-          keys:
-            - v9-cargo-cache-test-{{ arch }}-{{ .Branch }}
-            - v9-cargo-cache-test-{{ arch }}-
-
-      # Install nightly & wasm
-      - run:
-          name: Install Rust nightly
-          command: rustup update nightly && rustup default nightly
-      - run:
-          name: Add wasm32 target
-          command: rustup target add wasm32-unknown-unknown
-
-      # Install wasm tools
-      - run:
-          name: Install wasm-pack
-          command: >
-            curl -L https://github.com/rustwasm/wasm-pack/releases/download/v0.8.1/wasm-pack-v0.8.1-x86_64-unknown-linux-musl.tar.gz
-            | tar --strip-components=1 --wildcards -xzf - "*/wasm-pack"
-            && chmod +x wasm-pack
-            && mv wasm-pack $CARGO_HOME/bin/
-
-      # Install browsers
-      - run:
-          name: Install latest firefox
-          command: >
-            apt-get update
-            && apt-get install -y libgtk-3-0 libdbus-glib-1-2
-            && wget -q -O - "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64&lang=en-US" |  tar xj
-
-      # Show versions
-      - run:
-          name: Show versions
-          command: rustc --version && cargo --version && wasm-pack --version && firefox/firefox --version
-
-      # Run tests
-      - run:
-          name: Run all tests
-          command: PATH=$(pwd)/firefox:$PATH ./test.sh
-
-      # Save cache
-      - save_cache:
-          key: v9-cargo-cache-test-{{ arch }}-{{ .Branch }}
-          paths:
-            - target
-            - /usr/local/cargo
-      - save_cache:
-          key: v9-cargo-cache-test-{{ arch }}-
-          paths:
-            - target
-            - /usr/local/cargo
-
   docs-build:
     docker:
       - image: rust:latest
@@ -166,7 +96,6 @@ workflows:
   version: 2
   build:
     jobs:
-      - test
       - docs-build
       - docs-deploy:
           requires:

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: https://github.com/sponsors/chinedufn
+github: chinedufn
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,23 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+
+    - name: Rust Nightly
+      run: rustup update nightly && rustup default nightly
+
+    - name: wasm32 target
+      run: rustup target add wasm32-unknown-unknown
+
+    - name: Install wasm-pack
+      run: >
+            curl -L https://github.com/rustwasm/wasm-pack/releases/download/v0.8.1/wasm-pack-v0.8.1-x86_64-unknown-linux-musl.tar.gz
+            | tar --strip-components=1 --wildcards -xzf - "*/wasm-pack"
+            && chmod +x wasm-pack
+            && mv wasm-pack $CARGO_HOME/bin/
+
+
+    - name: Show Versions
+      run: rustc --version && cargo --version && wasm-pack --version && firefox --version
+
+    - name: Run all tests
+      run: ./test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: Percy CI
 
 on: [push]
 
@@ -9,9 +9,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - uses: actions-rs/cargo@v1
 
     - name: Rust Nightly
       run: rustup update nightly && rustup default nightly
+
+    - name: Rust Version Info
+      run: rustc --version && cargo --version && echo $CARGO_HOME
 
     - name: wasm32 target
       run: rustup target add wasm32-unknown-unknown
@@ -23,9 +27,8 @@ jobs:
             && chmod +x wasm-pack
             && mv wasm-pack $CARGO_HOME/bin/
 
-
-    - name: Show Versions
-      run: rustc --version && cargo --version && wasm-pack --version && firefox --version
+    - name: Browser versions
+      run: wasm-pack --version && firefox --version
 
     - name: Run all tests
       run: ./test.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Percy CI
 
 on: [push]
 
+# TODO: Introduce caching https://github.com/actions/cache/blob/master/examples.md#rust---cargo
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,23 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/cargo@v1
 
-    - name: Rust Nightly
-      run: rustup update nightly && rustup default nightly
+    - name: Latest Rust Nightly
+      uses: actions-rs/toolchain@v1
+      with:
+          toolchain: nightly
+          override: true
+          # Used when testing with `wasm-pack test`
+          target: wasm32-unknown-unknown
 
     - name: Rust Version Info
       run: rustc --version && cargo --version && echo $CARGO_HOME
-
-    - name: wasm32 target
-      run: rustup target add wasm32-unknown-unknown
 
     - name: Install wasm-pack
       run: >
             curl -L https://github.com/rustwasm/wasm-pack/releases/download/v0.8.1/wasm-pack-v0.8.1-x86_64-unknown-linux-musl.tar.gz
             | tar --strip-components=1 --wildcards -xzf - "*/wasm-pack"
             && chmod +x wasm-pack
-            && mv wasm-pack $CARGO_HOME/bin/
+            && mv wasm-pack $HOME/.cargo/bin/
 
     - name: Browser versions
       run: wasm-pack --version && firefox --version

--- a/crates/virtual-dom-rs/src/patch/mod.rs
+++ b/crates/virtual-dom-rs/src/patch/mod.rs
@@ -20,7 +20,7 @@ pub use apply_patches::patch;
 /// Our old virtual dom's nodes are indexed depth first, as shown in this illustration
 /// (0 being the root node, 1 being it's first child, 2 being it's first child's first child).
 ///
-/// ```ignore
+/// ```text
 ///             .─.
 ///            ( 0 )
 ///             `┬'


### PR DESCRIPTION
Firefox wasn't working in TravisCI. After trying to figure out why for about an hour I gave up and remembered that I've been meaning to evaluate GitHub actions.

GitHub actions just so happen to come with Firefox pre-installed - so the setup was pretty painless.

In the future we'll want to move the book deployment job away from TravisCI so that everything is all in GitHub actions - but we can keep it in Travis for now.

Fixes #137 

\cc @rickihastings 