### PR TITLE
Custom Components

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -9,6 +9,7 @@
     - [Writing html!](./html-macro/html-macro.md)
     - [Compile Time Errors](./html-macro/compile-time-errors.md)
     - [Working with Text](./html-macro/text/README.md)
+    - [Custom Components](./html-macro/custom-components/README.md)
     - [Setting Inner HTML](./html-macro/setting-inner-html/README.md)
     - [Conditional Rendering](./html-macro/conditional-rendering/README.md)
     - [Real Elements and Nodes](./html-macro/real-elements-and-nodes/on-create-elem/README.md)

--- a/book/src/html-macro/custom-components/README.md
+++ b/book/src/html-macro/custom-components/README.md
@@ -1,0 +1,31 @@
+# Custom Components
+
+Percy's `html!` macro supports custom components.
+
+You can create a component by implementing the `View` trait.
+
+Here is an example:
+
+```rust
+fn page() -> VirtualNode {
+    html! {
+        <div>
+            <ChildView count={0}/>
+        </div>
+    }
+}
+
+struct ChildView {
+    count: u8,
+}
+
+impl View for ChildView {
+    fn render(&self) -> VirtualNode {
+        html! {
+            <div>
+                Count is {format!("{}", self.count)}
+            </div>
+        }
+    }
+}
+```

--- a/crates/html-macro-test/src/tests/all_tests.rs
+++ b/crates/html-macro-test/src/tests/all_tests.rs
@@ -7,7 +7,7 @@
 
 use html_macro::html;
 use std::collections::HashMap;
-use virtual_node::{IterableNodes, VElement, VText, VirtualNode};
+use virtual_node::{IterableNodes, VElement, VText, View, VirtualNode};
 
 struct HtmlMacroTest {
     generated: VirtualNode,
@@ -314,6 +314,62 @@ fn single_branch_if_false_block() {
     HtmlMacroTest {
         generated: html! {
           <div>{if false {child_valid}}</div>
+        },
+        expected: expected.into(),
+    }
+    .test();
+}
+
+#[test]
+fn custom_component_props() {
+    struct Counter {
+        count: u8,
+    }
+
+    impl View for Counter {
+        fn render(&self) -> VirtualNode {
+            html! {
+                <span>Counter = {format!("{}", self.count)}</span>
+            }
+        }
+    }
+
+    let mut expected = VElement::new("div");
+    let mut child = VElement::new("span");
+    child.children = vec![VirtualNode::text("Counter = "), VirtualNode::text("1")];
+    expected.children = vec![child.into()];
+
+    HtmlMacroTest {
+        generated: html! {
+          <div><Counter count={1}/></div>
+        },
+        expected: expected.into(),
+    }
+    .test();
+}
+
+#[test]
+fn custom_component_children() {
+    struct Child;
+
+    impl View for Child {
+        fn render(&self) -> VirtualNode {
+            html! {
+                <span></span>
+            }
+        }
+    }
+
+    let mut expected = VElement::new("div");
+    let mut child = VElement::new("span");
+    child.children = vec![VirtualNode::text("Hello World")];
+    expected.children = vec![child.into()];
+
+    HtmlMacroTest {
+        generated: html! {
+          <div>
+            <Child>Hello World</Child>
+          </div>
         },
         expected: expected.into(),
     }

--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -74,9 +74,10 @@ impl HtmlParser {
                 name,
                 attrs,
                 closing_bracket_span,
+                is_self_closing,
                 ..
             } => {
-                self.parse_open_tag(name, closing_bracket_span, attrs);
+                self.parse_open_tag(name, closing_bracket_span, attrs, is_self_closing);
                 self.last_tag_kind = Some(TagKind::Open);
             }
             Tag::Close { name, .. } => {
@@ -128,13 +129,15 @@ impl HtmlParser {
                         let unreachable = quote_spanned!(Span::call_site() => {
                             unreachable!("Non-elements cannot have children");
                         });
+
                         let push_children = quote! {
-                            if let Some(ref mut element_node) =  #parent_name.as_velement_mut() {
+                            if let Some(ref mut element_node) = #parent_name.as_velement_mut() {
                                 element_node.children.extend(#children.into_iter());
                             } else {
                                 #unreachable;
                             }
                         };
+                        
                         tokens.push(push_children);
                     }
                 }
@@ -260,4 +263,8 @@ struct RecentSpanLocations {
 
 fn is_self_closing(tag: &str) -> bool {
     html_validation::is_self_closing(tag)
+}
+
+fn is_valid_tag(tag: &str) -> bool {
+    html_validation::is_valid_tag(tag)
 }

--- a/crates/html-macro/src/parser/open_tag.rs
+++ b/crates/html-macro/src/parser/open_tag.rs
@@ -1,4 +1,4 @@
-use crate::parser::{is_self_closing, HtmlParser};
+use crate::parser::{is_self_closing, is_valid_tag, HtmlParser};
 use crate::tag::Attr;
 use proc_macro2::{Ident, Span};
 use quote::quote;
@@ -6,7 +6,13 @@ use syn::Expr;
 
 impl HtmlParser {
     /// Parse an incoming Tag::Open
-    pub(crate) fn parse_open_tag(&mut self, name: &Ident, closing_span: &Span, attrs: &Vec<Attr>) {
+    pub(crate) fn parse_open_tag(
+        &mut self,
+        name: &Ident,
+        closing_span: &Span,
+        attrs: &Vec<Attr>,
+        is_self_closing_tag: &bool
+    ) {
         self.set_most_recent_open_tag_end(closing_span.clone());
 
         let idx = &mut self.current_node_idx;
@@ -20,46 +26,75 @@ impl HtmlParser {
         // TODO: Not sure what the span is supposed to be so I just picked something..
         let var_name_node = Ident::new(format!("node_{}", idx).as_str(), name.span());
         let html_tag = format!("{}", name);
+        let is_html_tag = is_valid_tag(&html_tag);
 
-        let node = quote! {
-            let mut #var_name_node = VirtualNode::element(#html_tag);
-        };
-        tokens.push(node);
-
-        for attr in attrs.iter() {
-            let key = format!("{}", attr.key);
-            let value = &attr.value;
-
-            match value {
-                Expr::Closure(closure) => {
-                    // TODO: Use this to decide Box<FnMut(_, _, _, ...)
-                    // After we merge the DomUpdater
-                    let _arg_count = closure.inputs.len();
-
-                    // NOTE: Closures don't work on non wasm32 targets so we only add
-                    // events on wasm32 targets.
-                    let add_closure = quote! {
-                        #[cfg(target_arch = "wasm32")]
-                        {
-                          let closure = Closure::wrap(
-                              Box::new(#value) as Box<FnMut(_)>
-                          );
-                          let closure_rc = std::rc::Rc::new(closure);
-                          #var_name_node.as_velement_mut().expect("Not an element")
-                              .events.0.insert(#key.to_string(), closure_rc);
-                        }
-                    };
-
-                    tokens.push(add_closure);
-                }
-                _ => {
-                    let insert_attribute = quote! {
-                        #var_name_node.as_velement_mut().expect("Not an element")
-                            .attrs.insert(#key.to_string(), #value.to_string());
-                    };
-                    tokens.push(insert_attribute);
-                }
+        // TODO: Maybe this could be split up into two functions at some point, would have to pass
+        // a lot of vars around though, which isn't very nice.
+        if is_html_tag {
+            let node = quote! {
+                let mut #var_name_node = VirtualNode::element(#html_tag);
             };
+
+            tokens.push(node);
+
+            for attr in attrs.iter() {
+                let key = format!("{}", attr.key);
+                let value = &attr.value;
+
+                match value {
+                    Expr::Closure(closure) => {
+                        // TODO: Use this to decide Box<FnMut(_, _, _, ...)
+                        // After we merge the DomUpdater
+                        let _arg_count = closure.inputs.len();
+
+                        // NOTE: Closures don't work on non wasm32 targets so we only add
+                        // events on wasm32 targets.
+                        let add_closure = quote! {
+                            #[cfg(target_arch = "wasm32")]
+                            {
+                                let closure = Closure::wrap(
+                                    Box::new(#value) as Box<FnMut(_)>
+                                );
+                                let closure_rc = std::rc::Rc::new(closure);
+                                #var_name_node.as_velement_mut().expect("Not an element")
+                                    .events.0.insert(#key.to_string(), closure_rc);
+                            }
+                        };
+
+                        tokens.push(add_closure);
+                    }
+                    _ => {
+                        let insert_attribute = quote! {
+                            #var_name_node.as_velement_mut().expect("Not an element")
+                                .attrs.insert(#key.to_string(), #value.to_string());
+                        };
+
+                        tokens.push(insert_attribute);
+                    }
+                };
+            }
+        } else {
+            let var_name_component = Ident::new(format!("component_{}", idx).as_str(), name.span());
+            let component_ident = Ident::new(format!("{}", html_tag).as_str(), name.span());
+
+            let component_props: Vec<proc_macro2::TokenStream> = attrs
+                .into_iter()
+                .map(|attr| {
+                    let key = Ident::new(format!("{}", attr.key).as_str(), name.span());
+                    let value = &attr.value;
+
+                    quote! {
+                        #key: #value,
+                    }
+                })
+                .collect();
+
+            let node = quote! {
+                let mut #var_name_component = #component_ident { #(#component_props),* };
+                let mut #var_name_node = #var_name_component.render();
+            };
+
+            tokens.push(node);
         }
 
         // The first open tag that we see is our root node so we won't worry about
@@ -67,7 +102,7 @@ impl HtmlParser {
         if *idx == 0 {
             node_order.push(0);
 
-            if !is_self_closing(&html_tag) {
+            if !is_self_closing(&html_tag) && !is_self_closing_tag {
                 parent_stack.push((0, name.clone()));
             }
 
@@ -77,9 +112,10 @@ impl HtmlParser {
 
         let parent_idx = *&parent_stack[parent_stack.len() - 1].0;
 
-        if !is_self_closing(&html_tag) {
+        if !is_self_closing(&html_tag) && !is_self_closing_tag {
             parent_stack.push((*idx, name.clone()));
         }
+
         node_order.push(*idx);
 
         parent_to_children

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -16,6 +16,7 @@ pub enum Tag {
         attrs: Vec<Attr>,
         open_bracket_span: Span,
         closing_bracket_span: Span,
+        is_self_closing: bool,
     },
     /// </div>
     Close {
@@ -108,8 +109,8 @@ fn parse_open_tag(input: &mut ParseStream, open_bracket_span: Span) -> Result<Ta
 
     let attrs = parse_attributes(input)?;
 
-    let _maybe_trailing_slash: Option<Token![/]> = input.parse()?;
-    //    let has_trailing_slash = has_trailing_slash.is_some();
+    let is_self_closing: Option<Token![/]> = input.parse()?;
+    let is_self_closing = is_self_closing.is_some();
 
     let closing_bracket = input.parse::<Token![>]>()?;
     let closing_bracket_span = closing_bracket.span();
@@ -119,6 +120,7 @@ fn parse_open_tag(input: &mut ParseStream, open_bracket_span: Span) -> Result<Ta
         attrs,
         open_bracket_span,
         closing_bracket_span,
+        is_self_closing
     })
 }
 

--- a/crates/html-validation/src/lib.rs
+++ b/crates/html-validation/src/lib.rs
@@ -35,6 +35,8 @@
 
 pub use self_closing::is_self_closing;
 pub use svg_namespace::is_svg_namespace;
+pub use valid_tags::is_valid_tag;
 
 mod self_closing;
 mod svg_namespace;
+mod valid_tags;

--- a/crates/html-validation/src/valid_tags.rs
+++ b/crates/html-validation/src/valid_tags.rs
@@ -1,0 +1,35 @@
+use lazy_static::lazy_static;
+use std::collections::hash_set::HashSet;
+
+use super::svg_namespace::is_svg_namespace;
+
+lazy_static! {
+    static ref VALID_TAGS: HashSet<&'static str> = [
+        "a","abbr","address","area","article","aside","audio","b","base","bdi","bdo","big",
+        "blockquote","body","br","button","canvas","caption","cite","code","col","colgroup",
+        "command", "data","datalist","dd","del","details","dfn","dialog","div","dl","dt","em","embed",
+        "fieldset","figcaption","figure","footer","form","h1","h2","h3","h4","h5","h6","head",
+        "header","hr","html","i","iframe","img","input","ins","kbd","keygen","label","legend",
+        "li","link","main","map","mark","menu","menuitem","meta","meter","nav","noscript","object",
+        "ol","optgroup","option","output","p","param","picture","pre","progress","q","rp","rt",
+        "ruby","s","samp","script","section","select","small","source","span","strong","style",
+        "sub","summary","sup","table","tbody","td","textarea","tfoot","th","thead","time","title",
+        "tr","track","u","ul","var","video","wbr",
+    ]
+    .iter()
+    .cloned()
+    .collect();
+}
+
+/// Whether or not this tag is valid
+///
+/// ```
+/// use html_validation::is_valid_tag;
+///
+/// assert_eq!(is_valid_tag("br"), true);
+///
+/// assert_eq!(is_valid_tag("random"), false);
+/// ```
+pub fn is_valid_tag(tag: &str) -> bool {
+    VALID_TAGS.contains(tag) || is_svg_namespace(tag)
+}


### PR DESCRIPTION
I've implemented custom components in Percy, similar to what you see in React, so users can use a `<MyComponent/>` pattern rather than `{my_component()}` which feels a bit more up to date with competitor frameworks.

I've had to implement a list of valid html tags to do this (I took them from [here](https://react-cn.github.io/react/docs/tags-and-attributes.html)).

If this isn't the best way of going around this please let me know, or if this is an unwanted change then that's fine too.

I tried to implement children in the same way React handles them, ie a children prop gets added into the child component but I've been round in circles with this - I kept hitting borrowing problems. I also had a look how Yew does it (which is similar to React) and still couldn't figure out a nice way of doing it. Any help on this would be appreciated. Children actually do work but they're just appended to the end of the parent, like in the normal HTML tags. I'm hoping it wouldn't require a huge refactor for it.