### PR TITLE
IterableNodes: add From<&[View]>, From<&Vec<View>>, and From<Vec<View>>

### DIFF
--- a/crates/html-macro/src/parser/mod.rs
+++ b/crates/html-macro/src/parser/mod.rs
@@ -224,7 +224,7 @@ impl HtmlParser {
                 let node_ident = self.new_virtual_node_ident(stmt.span());
 
                 self.push_tokens(quote! {
-                    let mut #node_ident: IterableNodes = #stmt.into();
+                    let mut #node_ident: IterableNodes = (#stmt).into();
                 });
             }
             NodesToPush::TokenStream(stmt, tokens) => {

--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -452,6 +452,24 @@ impl From<Vec<VirtualNode>> for IterableNodes {
     }
 }
 
+impl<V: View> From<Vec<V>> for IterableNodes {
+    fn from(other: Vec<V>) -> Self {
+      IterableNodes(other.into_iter().map(|it| it.render()).collect())
+    }
+}
+
+impl<V: View> From<&Vec<V>> for IterableNodes {
+    fn from(other: &Vec<V>) -> Self {
+      IterableNodes(other.iter().map(|it| it.render()).collect())
+    }
+}
+
+impl<V: View> From<&[V]> for IterableNodes {
+    fn from(other: &[V]) -> Self {
+      IterableNodes(other.iter().map(|it| it.render()).collect())
+    }
+}
+
 impl From<VText> for VirtualNode {
     fn from(other: VText) -> Self {
         VirtualNode::Text(other)


### PR DESCRIPTION
For convenience.

Also, in html macro, add parenthesis around statements before calling `.into()` so that we can use references.

I'm a bit lazy and I don't want to `.map(|v| v.render).collect()` my views myself 😄