### PR TITLE
Fix setting events ID

### DIFF
--- a/crates/percy-dom/src/patch.rs
+++ b/crates/percy-dom/src/patch.rs
@@ -47,6 +47,8 @@ type NodeIdx = u32;
 /// The patching process is tested in a real browser in crates/percy-dom/tests/diff_patch.rs
 #[derive(Debug)]
 #[cfg_attr(any(test, feature = "__test-utils"), derive(PartialEq))]
+// TODO: Change all of these tuple structs with a `NodeIdx` to instead be `{old_idx: NodeIdx`} so
+//  we can more easily tell which patches use the old node's index vs. the new one's.
 pub enum Patch<'a> {
     /// Append a vector of child nodes to a parent node id.
     #[allow(missing_docs)]
@@ -79,7 +81,8 @@ pub enum Patch<'a> {
     /// This happens when the node no longer has any events.
     RemoveEventsId(NodeIdx),
     /// Set the `__events_id__` property on the DOM node.
-    SetEventsId(NodeIdx),
+    #[allow(missing_docs)]
+    SetEventsId { old_idx: NodeIdx, new_idx: NodeIdx },
     /// Insert events in the EventsByNodeIdx.
     /// If it is a non-delegated event the event will also get added to the DOM node.
     AddEvents(NodeIdx, HashMap<&'a EventName, &'a EventHandler>),
@@ -124,7 +127,7 @@ impl<'a> Patch<'a> {
                 PatchSpecialAttribute::CallOnRemoveElem(node_idx, _) => *node_idx,
             },
             Patch::RemoveEventsId(node_idx) => *node_idx,
-            Patch::SetEventsId(node_idx) => *node_idx,
+            Patch::SetEventsId { old_idx, .. } => *old_idx,
             Patch::RemoveEvents(node_idx, _) => *node_idx,
             Patch::AddEvents(node_idx, _) => *node_idx,
             Patch::RemoveAllManagedEventsWithNodeIdx(node_idx) => {

--- a/crates/percy-dom/src/patch/apply_patches.rs
+++ b/crates/percy-dom/src/patch/apply_patches.rs
@@ -289,13 +289,19 @@ fn apply_element_patch(
 
             Ok(())
         }
-        Patch::SetEventsId(node_idx) => {
+        Patch::SetEventsId { old_idx, new_idx } => {
             js_sys::Reflect::set(
                 node,
                 &EVENTS_ID_PROP.into(),
-                &format!("{}{}", managed_events.events_id_props_prefix(), node_idx).into(),
+                &format!("{}{}", managed_events.events_id_props_prefix(), new_idx).into(),
             )
             .unwrap();
+
+            let move_over_old_events = old_idx != new_idx;
+
+            if move_over_old_events {
+                managed_events.move_events(old_idx, *new_idx);
+            }
 
             Ok(())
         }

--- a/crates/virtual-node/src/event/events_by_node_idx.rs
+++ b/crates/virtual-node/src/event/events_by_node_idx.rs
@@ -106,6 +106,7 @@ impl EventsByNodeIdx {
         event: EventHandler,
     ) {
         let mut events = self.events.borrow_mut();
+
         let func = match events
             .entry(node_idx)
             .or_default()
@@ -117,6 +118,15 @@ impl EventsByNodeIdx {
         };
 
         *func = event;
+    }
+
+    /// Remove all of the events from one node ID and add them to another node ID.
+    pub fn move_events(&mut self, old_node_id: &u32, new_node_id: u32) {
+        let mut events = self.events.borrow_mut();
+
+        if let Some(old_events) = events.remove(old_node_id) {
+            events.insert(new_node_id, old_events);
+        }
     }
 
     /// Remove a managed event.


### PR DESCRIPTION
When old nodes are removed/added, the events ID on nodes that come after
those nodes in the tree need to be updated.

This commit implements this, so that nodes get their events ID updated
as they move around the tree.
