### PR TITLE
Support the as attribute in link tags.

### DIFF
--- a/crates/html-macro-test/src/tests/all_tests.rs
+++ b/crates/html-macro-test/src/tests/all_tests.rs
@@ -182,9 +182,10 @@ fn vec_of_nodes() {
     .test();
 }
 
-/// Just make sure that this compiles since async, for, loop, and type are keywords
+/// Just make sure that this compiles since as, async, for, loop, and type are keywords
 #[test]
 fn keyword_attribute() {
+    html! { <link rel="prefetch" href="/style.css" as="style" /> };
     html! { <script src="/app.js" async="async" /> };
     html! { <label for="username">Username:</label> };
     html! { <audio loop="loop"><source src="/beep.mp3" type="audio/mpeg" /></audio> };

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -153,7 +153,7 @@ fn parse_attributes(input: &mut ParseStream) -> Result<Vec<Attr>> {
             Ident::new("as", maybe_as_key.unwrap().span())
         } else if maybe_async_key.is_some() {
             Ident::new("async", maybe_async_key.unwrap().span())
-        }else if maybe_for_key.is_some() {
+        } else if maybe_for_key.is_some() {
             Ident::new("for", maybe_for_key.unwrap().span())
         } else if maybe_loop_key.is_some() {
             Ident::new("loop", maybe_loop_key.unwrap().span())

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -135,21 +135,25 @@ fn parse_attributes(input: &mut ParseStream) -> Result<Vec<Attr>> {
 
     // Do we see an identifier such as `id`? If so proceed
     while input.peek(Ident)
+        || input.peek(Token![as])
         || input.peek(Token![async])
         || input.peek(Token![for])
         || input.peek(Token![loop])
         || input.peek(Token![type])
     {
         // <link rel="stylesheet" type="text/css"
-        //   .. async, for, loop, type need to be handled specially since they are keywords
+        //   .. as, async, for, loop, type need to be handled specially since they are keywords
+        let maybe_as_key: Option<Token![as]> = input.parse()?;
         let maybe_async_key: Option<Token![async]> = input.parse()?;
         let maybe_for_key: Option<Token![for]> = input.parse()?;
         let maybe_loop_key: Option<Token![loop]> = input.parse()?;
         let maybe_type_key: Option<Token![type]> = input.parse()?;
 
-        let key = if maybe_async_key.is_some() {
+        let key = if maybe_as_key.is_some() {
+            Ident::new("as", maybe_as_key.unwrap().span())
+        } else if maybe_async_key.is_some() {
             Ident::new("async", maybe_async_key.unwrap().span())
-        } else if maybe_for_key.is_some() {
+        }else if maybe_for_key.is_some() {
             Ident::new("for", maybe_for_key.unwrap().span())
         } else if maybe_loop_key.is_some() {
             Ident::new("loop", maybe_loop_key.unwrap().span())
@@ -170,6 +174,7 @@ fn parse_attributes(input: &mut ParseStream) -> Result<Vec<Attr>> {
             value_tokens.extend(Some(tt));
 
             let has_attrib_key = input.peek(Ident)
+                || input.peek(Token![as])
                 || input.peek(Token![async])
                 || input.peek(Token![for])
                 || input.peek(Token![loop])


### PR DESCRIPTION
Similar to #131, this adds support for `as` attributes in html tags, since `as` is a keyword in Rust. [`as` is used in prefetch/preload link tags](https://3perf.com/blog/link-rels/).

Thanks!