### PR TITLE
Add render fn to percy-dom

### DIFF
--- a/crates/html-macro-test/src/tests/ui/invalid_html_tag.rs
+++ b/crates/html-macro-test/src/tests/ui/invalid_html_tag.rs
@@ -1,3 +1,7 @@
+//! # To Run
+//!
+//! cargo test -p html-macro-test --lib ui -- trybuild=invalid_html_tag.rs
+
 extern crate percy_dom;
 use percy_dom::prelude::*;
 

--- a/crates/html-macro-test/src/tests/ui/invalid_html_tag.stderr
+++ b/crates/html-macro-test/src/tests/ui/invalid_html_tag.stderr
@@ -1,11 +1,11 @@
 error: invalidtagname is not a valid HTML tag.
 
-If you are trying to use a valid HTML tag, perhaps there's a typo?
+       If you are trying to use a valid HTML tag, perhaps there's a typo?
 
-If you are trying to use a custom component, please capitalize the component name.
+       If you are trying to use a custom component, please capitalize the component name.
 
-custom components: https://chinedufn.github.io/percy/html-macro/custom-components/index.html
- --> $DIR/invalid_html_tag.rs:7:10
-  |
-7 |         <invalidtagname></invalidtagname>
-  |          ^^^^^^^^^^^^^^
+       custom components: https://chinedufn.github.io/percy/html-macro/custom-components/index.html
+  --> src/tests/ui/invalid_html_tag.rs
+   |
+   |         <invalidtagname></invalidtagname>
+   |          ^^^^^^^^^^^^^^

--- a/crates/html-macro-test/src/tests/ui/on_create_element_without_key.rs
+++ b/crates/html-macro-test/src/tests/ui/on_create_element_without_key.rs
@@ -1,3 +1,7 @@
+//! # To Run
+//!
+//! cargo test -p html-macro-test --lib ui -- trybuild=on_create_element_without_key.rs
+
 extern crate percy_dom;
 use percy_dom::prelude::*;
 

--- a/crates/html-macro-test/src/tests/ui/on_create_element_without_key.stderr
+++ b/crates/html-macro-test/src/tests/ui/on_create_element_without_key.stderr
@@ -1,10 +1,10 @@
 error: Whenever you use the `on_create_element=...` attribute,
-you must also use must use the `key="..."` attribute.
+       you must also use must use the `key="..."` attribute.
 
-Documentation:
-  -> https://chinedufn.github.io/percy/html-macro/real-elements-and-nodes/on-create-elem/index.html
+       Documentation:
+         -> https://chinedufn.github.io/percy/html-macro/real-elements-and-nodes/on-create-elem/index.html
 
- --> src/tests/ui/on_create_element_without_key.rs
-  |
-  |         <div on_create_element = ||{} >
-  |              ^^^^^^^^^^^^^^^^^
+  --> src/tests/ui/on_create_element_without_key.rs
+   |
+   |         <div on_create_element = ||{} >
+   |              ^^^^^^^^^^^^^^^^^

--- a/crates/html-macro-test/src/tests/ui/on_remove_element_without_key.rs
+++ b/crates/html-macro-test/src/tests/ui/on_remove_element_without_key.rs
@@ -1,3 +1,7 @@
+//! # To Run
+//!
+//! cargo test -p html-macro-test --lib ui -- trybuild=on_remove_element_without_key.rs
+
 extern crate percy_dom;
 use percy_dom::prelude::*;
 

--- a/crates/html-macro-test/src/tests/ui/on_remove_element_without_key.stderr
+++ b/crates/html-macro-test/src/tests/ui/on_remove_element_without_key.stderr
@@ -1,10 +1,10 @@
 error: Whenever you use the `on_remove_element=...` attribute,
-you must also use must use the `key="..."` attribute.
+       you must also use must use the `key="..."` attribute.
 
-Documentation:
-  -> https://chinedufn.github.io/percy/html-macro/real-elements-and-nodes/on-remove-elem/index.html
+       Documentation:
+         -> https://chinedufn.github.io/percy/html-macro/real-elements-and-nodes/on-remove-elem/index.html
 
- --> src/tests/ui/on_remove_element_without_key.rs
-  |
-  |         <div on_remove_element = ||{} >
-  |              ^^^^^^^^^^^^^^^^^
+  --> src/tests/ui/on_remove_element_without_key.rs
+   |
+   |         <div on_remove_element = ||{} >
+   |              ^^^^^^^^^^^^^^^^^

--- a/crates/percy-dom/Cargo.toml
+++ b/crates/percy-dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "percy-dom"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 description = "A standalone Virtual DOM creation, diffing and patching implementation"
 keywords = ["virtual", "dom", "wasm", "assembly", "webassembly"]

--- a/crates/percy-dom/src/lib.rs
+++ b/crates/percy-dom/src/lib.rs
@@ -25,6 +25,8 @@ mod diff;
 mod patch;
 mod pdom;
 
+pub mod render;
+
 /// Exports structs and macros that you'll almost always want access to in a virtual-dom
 /// powered application
 pub mod prelude {

--- a/crates/percy-dom/src/render.rs
+++ b/crates/percy-dom/src/render.rs
@@ -1,0 +1,88 @@
+//! Utilities to help with rendering.
+
+use crate::{PercyDom, VirtualNode};
+use std::{cell::Cell, rc::Rc};
+use wasm_bindgen::prelude::Closure;
+use wasm_bindgen::JsCast;
+
+/// Given a [`PercyDom`] and a function that renders a [`VirtualNode`],
+/// return a function that can call that render function up to once per browser
+/// animation frame.
+///
+/// The returned `VirtualNode` is used to update the `PercyDom` instance.
+///
+/// After the first call to the returned render function, further calls will be
+/// ignored until the next render, at after which you will be able to schedule
+/// another render again.
+///
+/// This is useful for when your application state changes and you want to schedule
+/// a re-render to occur on the next animation frame.
+///
+/// # Example
+///
+/// ```
+/// # use percy_dom::{
+/// #    prelude::*,
+/// #    render::create_render_scheduler
+/// # };
+///
+/// struct MyApp {
+///     counter: u8
+/// }
+///
+/// impl MyApp {
+///     fn render(&self) -> VirtualNode {
+///         html! { <div>Count: { self.counter }</div> }
+///     }
+/// }
+///
+/// fn start () {
+///     let app = MyApp { counter: 5 };
+///     let pdom = make_percy_dom_somehow();
+///
+///     let mut render = create_render_scheduler(
+///         pdom,
+///         move || {
+///             app.render()
+///         }
+///     );
+///
+///     // In a real application you might call this whenever your
+///     // application state changes.
+///     render();
+/// }
+///
+/// # fn make_percy_dom_somehow() -> PercyDom { unimplemented!() }
+/// ```
+pub fn create_render_scheduler<F: FnMut() -> VirtualNode + 'static>(
+    mut percy_dom: PercyDom,
+    mut render: F,
+) -> Box<dyn FnMut()> {
+    let render_is_scheduled = Rc::new(Cell::new(false));
+    let render_is_scheduled_clone = render_is_scheduled.clone();
+
+    let render = move || {
+        render_is_scheduled.set(false);
+
+        let vdom = render();
+        percy_dom.update(vdom);
+    };
+
+    let render = Box::new(render) as Box<dyn FnMut()>;
+    let render = Closure::wrap(render);
+
+    let window = web_sys::window().unwrap();
+    let render_raf = move || {
+        if render_is_scheduled_clone.get() {
+            return;
+        }
+
+        render_is_scheduled_clone.set(true);
+
+        window
+            .request_animation_frame(render.as_ref().as_ref().unchecked_ref())
+            .unwrap();
+    };
+
+    Box::new(render_raf) as Box<dyn FnMut() -> ()>
+}

--- a/crates/percy-router/Cargo.toml
+++ b/crates/percy-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "percy-router"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 edition = "2018"
 description = "A router for client side web applications with server side rendering support"
@@ -11,5 +11,5 @@ documentation = "https://chinedufn.github.io/percy/api/percy_router/"
 
 
 [dependencies]
-percy-dom = { path = "../percy-dom", version = "0.7.1"}
+percy-dom = { path = "../percy-dom", version = "0.7.2"}
 percy-router-macro = { path = "../percy-router-macro", version = "0.1.5" }


### PR DESCRIPTION
This commit adds a function to percy-dom that can be used to create a
request-animation-frame throttled renderer.

This is helpful for powering experiences where you want to rerender
an application everytime application state changes.
