### PR TITLE
Introduce percy-preview

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ members = [
   "crates/percy-css",
   "crates/percy-dom",
   "crates/percy-css-macro",
+  "crates/percy-preview",
+  "crates/percy-preview-app",
   "crates/percy-router",
   "crates/percy-router-macro",
   "crates/percy-router-macro-test",

--- a/crates/percy-dom/tests/testing_utilities.rs
+++ b/crates/percy-dom/tests/testing_utilities.rs
@@ -9,7 +9,7 @@ pub fn document() -> web_sys::Document {
     web_sys::window().unwrap().document().unwrap()
 }
 
-pub fn append_to_document (elem: &web_sys::Element) {
+pub fn append_to_document(elem: &web_sys::Element) {
     document().body().unwrap().append_child(elem).unwrap();
 }
 

--- a/crates/percy-preview-app/Cargo.toml
+++ b/crates/percy-preview-app/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "percy-preview-app"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+app-world = "0.1"
+console_error_panic_hook = "0.1"
+js-sys = "0.3"
+percy-dom = {path = "../percy-dom"}
+percy-router = {path = "../percy-router"}
+percy-preview = {path = "../percy-preview"}
+wasm-bindgen = "0.2.80"
+
+[dependencies.web-sys]
+version = "0.3"
+features = [
+    "Document",
+    "HtmlElement",
+    "Window",
+    "console",
+]

--- a/crates/percy-preview-app/src/app.rs
+++ b/crates/percy-preview-app/src/app.rs
@@ -1,0 +1,35 @@
+use std::sync::{Arc, Mutex};
+
+use crate::create_router;
+use app_world::AppWorldWrapper;
+
+mod config;
+
+pub use self::config::AppConfig;
+
+mod world;
+pub(crate) use self::world::World;
+use self::world::{create_world, Msg, WorldConfig};
+
+/// Powers an application that can be used to preview view components.
+pub(crate) struct PercyPreviewApp {
+    pub(crate) world: AppWorldWrapper<World>,
+}
+
+impl PercyPreviewApp {
+    /// Create a new PercyPreviewApp.
+    pub fn new(config: AppConfig, render: Arc<Mutex<Box<dyn FnMut() -> ()>>>) -> Self {
+        let router = create_router();
+
+        let world = create_world(WorldConfig {
+            previews: config.previews,
+            render,
+            router,
+        });
+        let world = AppWorldWrapper::new(world);
+
+        world.msg(Msg::ProvideRouteData);
+
+        Self { world }
+    }
+}

--- a/crates/percy-preview-app/src/app/config.rs
+++ b/crates/percy-preview-app/src/app/config.rs
@@ -1,0 +1,7 @@
+use percy_preview::Preview;
+
+/// Configuration for a PercyPreviewApp.
+pub struct AppConfig {
+    /// All of the view components previews.
+    pub previews: Vec<Preview>,
+}

--- a/crates/percy-preview-app/src/app/world.rs
+++ b/crates/percy-preview-app/src/app/world.rs
@@ -1,0 +1,24 @@
+mod message;
+pub use self::message::*;
+
+mod world_config;
+use self::resources::Resources;
+use self::state::State;
+pub(super) use self::world_config::WorldConfig;
+
+mod resources;
+mod state;
+
+pub(crate) struct World {
+    pub(crate) resources: Resources,
+    pub(crate) state: State,
+}
+
+pub(super) fn create_world(config: WorldConfig) -> World {
+    World {
+        state: State {},
+        resources: Resources {
+            router: config.router,
+        },
+    }
+}

--- a/crates/percy-preview-app/src/app/world/message.rs
+++ b/crates/percy-preview-app/src/app/world/message.rs
@@ -1,0 +1,8 @@
+mod message_handlers;
+
+/// Used to tell the World to handle some occurrence.
+///
+/// For example, a Msg might get sent when a button is clicked.
+pub enum Msg {
+    ProvideRouteData,
+}

--- a/crates/percy-preview-app/src/app/world/message/message_handlers.rs
+++ b/crates/percy-preview-app/src/app/world/message/message_handlers.rs
@@ -1,0 +1,16 @@
+use super::Msg;
+use crate::app::World;
+use app_world::AppWorld;
+use app_world::AppWorldWrapper;
+
+mod set_route_data_provider_message_handler;
+
+impl AppWorld for World {
+    type Message = Msg;
+
+    fn msg(&mut self, message: Self::Message, wrap: AppWorldWrapper<Self>) {
+        match message {
+            Msg::ProvideRouteData => self.set_route_data_provider_message_handler(wrap),
+        }
+    }
+}

--- a/crates/percy-preview-app/src/app/world/message/message_handlers/set_route_data_provider_message_handler.rs
+++ b/crates/percy-preview-app/src/app/world/message/message_handlers/set_route_data_provider_message_handler.rs
@@ -1,0 +1,10 @@
+use crate::routes::RouteDataProvider;
+use app_world::AppWorldWrapper;
+
+use crate::app::World;
+
+impl World {
+    pub(super) fn set_route_data_provider_message_handler(&mut self, wrap: AppWorldWrapper<Self>) {
+        self.resources.router.provide(RouteDataProvider::new(wrap));
+    }
+}

--- a/crates/percy-preview-app/src/app/world/resources.rs
+++ b/crates/percy-preview-app/src/app/world/resources.rs
@@ -1,0 +1,7 @@
+use percy_router::prelude::Router;
+
+/// Application resources.
+pub struct Resources {
+    /// See [`Router`]
+    pub(crate) router: Router,
+}

--- a/crates/percy-preview-app/src/app/world/state.rs
+++ b/crates/percy-preview-app/src/app/world/state.rs
@@ -1,0 +1,2 @@
+/// Application state.
+pub(crate) struct State {}

--- a/crates/percy-preview-app/src/app/world/world_config.rs
+++ b/crates/percy-preview-app/src/app/world/world_config.rs
@@ -1,0 +1,12 @@
+use percy_preview::Preview;
+use percy_router::prelude::Router;
+use std::sync::{Arc, Mutex};
+
+pub(crate) struct WorldConfig {
+    /// All of the view components that can be previewed.
+    pub previews: Vec<Preview>,
+    /// Used to re-render the application into the DOM.
+    pub render: Arc<Mutex<Box<dyn FnMut() -> ()>>>,
+    /// See [`Router`].
+    pub router: Router,
+}

--- a/crates/percy-preview-app/src/lib.rs
+++ b/crates/percy-preview-app/src/lib.rs
@@ -1,0 +1,59 @@
+//! Used to run an web application that lets you preview view components.
+
+#![deny(missing_docs)]
+
+use self::app::{AppConfig, PercyPreviewApp};
+use self::render::render_app;
+use std::sync::{Arc, Mutex};
+
+use percy_dom::{render::create_render_scheduler, PercyDom, VirtualNode};
+use routes::create_router;
+use wasm_bindgen::prelude::*;
+
+mod app;
+mod render;
+mod routes;
+mod view;
+
+/// A frontend web application that lets you preview your own application's view components.
+#[wasm_bindgen]
+pub struct PercyPreviewWebClient;
+
+impl PercyPreviewWebClient {
+    /// Create a new preview application and append the application to a DOM node.
+    pub fn append_to_mount(config: AppConfig, dom_selector_of_mount: &str) {
+        std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+
+        let render: Arc<Mutex<Box<dyn FnMut() -> ()>>> = Arc::new(Mutex::new(Box::new(|| {})));
+        let render_clone = Arc::clone(&render);
+
+        let app = PercyPreviewApp::new(config, render);
+
+        let pdom = create_percy_dom(dom_selector_of_mount, render_app(&app.world));
+
+        let render = move || render_app(&app.world);
+        let render = create_render_scheduler(pdom, render);
+
+        *render_clone.lock().unwrap() = render;
+    }
+}
+
+fn create_percy_dom(dom_selector_of_mount: &str, start_view: VirtualNode) -> PercyDom {
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+
+    let mount = document
+        .query_selector(dom_selector_of_mount)
+        .unwrap()
+        .unwrap();
+    let pdom = PercyDom::new_append_to_mount(start_view, &mount);
+    pdom
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foo() {}
+}

--- a/crates/percy-preview-app/src/render.rs
+++ b/crates/percy-preview-app/src/render.rs
@@ -1,0 +1,17 @@
+use crate::app::World;
+use app_world::AppWorldWrapper;
+use percy_dom::prelude::*;
+
+pub(super) fn render_app(app: &AppWorldWrapper<World>) -> VirtualNode {
+    let path = "/";
+
+    let view = app.read().resources.router.view(path);
+
+    if let Some(view) = view {
+        view
+    } else {
+        html! {
+            <div>404 page here</div>
+        }
+    }
+}

--- a/crates/percy-preview-app/src/routes.rs
+++ b/crates/percy-preview-app/src/routes.rs
@@ -1,0 +1,23 @@
+use crate::app::World;
+use app_world::AppWorldWrapper;
+use percy_router::prelude::*;
+
+pub(crate) fn create_router() -> Router {
+    use crate::view;
+
+    let router = Router::new(create_routes![view::index_route::render_index_route]);
+
+    router
+}
+
+/// Used to
+pub(crate) struct RouteDataProvider {
+    world: AppWorldWrapper<World>,
+}
+
+impl RouteDataProvider {
+    /// Create a new RouteDataProvider
+    pub fn new(world: AppWorldWrapper<World>) -> RouteDataProvider {
+        RouteDataProvider { world }
+    }
+}

--- a/crates/percy-preview-app/src/view.rs
+++ b/crates/percy-preview-app/src/view.rs
@@ -1,0 +1,1 @@
+pub mod index_route;

--- a/crates/percy-preview-app/src/view/index_route.rs
+++ b/crates/percy-preview-app/src/view/index_route.rs
@@ -1,0 +1,22 @@
+use crate::routes::RouteDataProvider;
+use percy_dom::prelude::*;
+use percy_router::prelude::*;
+
+impl RouteDataProvider {
+    fn get_index_route_data(&self) -> IndexRouteData {
+        IndexRouteData {}
+    }
+}
+
+struct IndexRouteData {
+    //
+}
+
+#[route(path = "/")]
+pub(crate) fn render_index_route(provider: Provided<RouteDataProvider>) -> VirtualNode {
+    let route_data = provider.get_index_route_data();
+
+    html! {
+        <div>Percy preview app here</div>
+    }
+}

--- a/crates/percy-preview-app/src/view/routes.rs
+++ b/crates/percy-preview-app/src/view/routes.rs
@@ -1,0 +1,15 @@
+use crate::app::World;
+use app_world::AppWorldWrapper;
+use percy_router::prelude::*;
+
+pub(crate) fn init_router(route_data_provider: RouteDataProvider) {
+    use crate::view;
+
+    let mut router = Router::new(create_routes![]);
+    router.provide(route_data_provider)
+}
+
+/// Used to
+pub(crate) struct RouteDataProvider {
+    world: AppWorldWrapper<World>,
+}

--- a/crates/percy-preview/Cargo.toml
+++ b/crates/percy-preview/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "percy-preview"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+virtual-node = {path = "../virtual-node"}

--- a/crates/percy-preview/README.md
+++ b/crates/percy-preview/README.md
@@ -1,0 +1,86 @@
+# percy-preview
+
+`percy-preview` helps you render an interactive preview of any view component in any state.
+
+## Usage
+
+Create a preview crate that depends on your application crate.
+
+```
+name = "my-app-preview"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+my-app = {path = "/path/to/my-app"}
+percy-preview-app = {version = "0.1"}
+```
+
+Your preview crate uses `percy-preview-app` to create an application that can render the `Vec<Preview>` that your app crate exposes.
+
+```
+// TODO... illustrate this.. actually better yet add an example preview application to the crate... and just let this documentation
+// focus on explaining the high level details before linking you off to the full example.
+```
+
+Here's an example of a function that can be used to preview one of your views.
+
+```rust
+use percy_dom::prelude::*;
+
+struct MyView {
+    count: u8,
+    increment_count: Box<dyn FnMut() -> ()>
+}
+
+impl View for MyView {
+	fn render(self) -> VirtualNode {
+        let MyView { count, mut increment_count } = self;
+
+		html! {
+		    <div
+		        on_click=move || { increment_count() }
+		    >
+		        The count is { count }
+		    </div>
+		}
+	}
+}
+
+#[cfg(feature = "preview")]
+mod previews {
+    use super::MyView;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    use percy_dom::prelude::*;
+    use percy_preview::{Preview, Rerender};
+
+    pub fn preview_my_view(rerender: Rerender>) -> Preview {
+        let count = Arc::new(AtomicU32::new(0));
+        let count_clone = count.clone();
+
+        let increment_count = Box::new(|| {
+            count_clone.fetch_add(1, Ordering::SeqCst);
+            rerender()
+        });
+
+        let render = move || {
+            let view = MyView {
+                count: count.load(Ordering::SeqCst),
+                increment_count,
+            };
+
+            html! {
+                <div> { view } </div>
+            }
+        };
+
+        Preview {
+            name: "My View".to_string(),
+            render: Box::new(render),
+        }
+    }
+}
+```

--- a/crates/percy-preview/src/lib.rs
+++ b/crates/percy-preview/src/lib.rs
@@ -1,0 +1,51 @@
+//! Preview view components.
+
+#![deny(missing_docs)]
+
+use virtual_node::VirtualNode;
+
+/// Allows the preview to trigger a rerender of itself.
+///
+/// For example, a preview for a component with a button that increments
+/// a counter might trigger a rerender whenever the button is clicked.
+pub type Rerender = std::rc::Rc<dyn FnMut() -> ()>;
+
+/// Describes a view component preview.
+pub struct Preview {
+    /// The name of this preview
+    name: UrlSafeString,
+    /// Render the preview
+    render: Box<dyn FnMut(Rerender) -> VirtualNode>,
+}
+
+/// A string that only contains letters, numbers, hyphens and underscores.
+pub struct UrlSafeString(String);
+
+impl Preview {
+    /// Create a new Preview.
+    pub fn new(name: UrlSafeString, render: Box<dyn FnMut(Rerender) -> VirtualNode>) -> Self {
+        Preview { name, render }
+    }
+
+    /// The name of the preview.
+    pub fn name(&self) -> &String {
+        &self.name.0
+    }
+}
+
+impl UrlSafeString {
+    /// If the String that contains only letters, numbers, hyphens and underscores,
+    /// we return the `UrlSafeString`.
+    /// Otherwise we return `None`.
+    pub fn new(string: String) -> Option<Self> {
+        let all_chars_valid = string
+            .chars()
+            .all(|char| char.is_alphanumeric() || char == '-' || char == '_');
+
+        if all_chars_valid {
+            Some(UrlSafeString(string))
+        } else {
+            None
+        }
+    }
+}

--- a/crates/percy-router-macro/src/route_macro.rs
+++ b/crates/percy-router-macro/src/route_macro.rs
@@ -70,7 +70,7 @@ pub fn route(
     let params = route_fn.route_fn.decl.inputs;
 
     // [u8, Provided<MyAppState>]
-    let types = as_param_types(&params);
+    let _types = as_param_types(&params);
 
     // path = "/route/path"
     let mut path = None;
@@ -131,7 +131,7 @@ fn gen_route_creator(
             .collect(),
         _ => unimplemented!(""),
     };
-    let path_params_map: HashSet<String> = path_params.clone().into_iter().collect();
+    let _path_params_map: HashSet<String> = path_params.clone().into_iter().collect();
 
     let mut path_param_types = vec![];
     for path_param in path_params.iter() {
@@ -395,7 +395,7 @@ fn as_param_types(params: &Punctuated<FnArg, Token![,]>) -> Vec<&Type> {
             match arg {
                 // some_param_name: type
                 FnArg::Captured(captured) => match captured.pat {
-                    Pat::Ident(ref pat) => &captured.ty,
+                    Pat::Ident(ref _pat) => &captured.ty,
                     _ => unimplemented!("TODO: What should happen for other patterns?"),
                 },
                 _ => unimplemented!("TODO: What should happen for non captured args?"),
@@ -449,7 +449,7 @@ impl Parse for RouteAttr {
 
         // path = "/my/route/here"
         let key = input.parse::<Ident>()?;
-        let equals = input.parse::<Token![=]>()?;
+        let _equals = input.parse::<Token![=]>()?;
 
         if key == "path" {
             let path_val = input.parse::<Lit>()?;

--- a/crates/percy-router/src/route.rs
+++ b/crates/percy-router/src/route.rs
@@ -1,5 +1,3 @@
-use percy_dom::VText;
-use percy_dom::VirtualNode;
 use std::fmt::Debug;
 use std::fmt::Error;
 use std::fmt::Formatter;
@@ -64,7 +62,7 @@ where
 /// Given a param_key &str and a param_val &str, get the corresponding route parameter
 ///
 /// ex: ("friend_count", "30")
-pub type ParseRouteParam = Box<Fn(&str, &str) -> Option<Box<dyn RouteParam>>>;
+pub type ParseRouteParam = Box<dyn Fn(&str, &str) -> Option<Box<dyn RouteParam>>>;
 
 /// A route specifies a path to match against. When a match is found a `view_creator` is used
 /// to return an `impl View` that can be used to render the appropriate content for that route.


### PR DESCRIPTION
This commit introduces the percy-preview and percy-preview-app crates.

These crates can be used to preview view components.
