### PR TITLE
Make Percy preview refresh on code change

### DIFF
--- a/crates/percy-cli/Cargo.toml
+++ b/crates/percy-cli/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 clap = {version = "3.1", features = ["derive"]}
-notify = "4"
 percy-preview-server = {path = "../percy-preview-server"}
 tempfile = "3"
 tokio = {version = "1", features = ["rt"]}

--- a/crates/percy-cli/src/subcommand/preview.rs
+++ b/crates/percy-cli/src/subcommand/preview.rs
@@ -1,21 +1,15 @@
 use clap::Parser;
-use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
 use percy_preview_server::{start_server, ServerConfig};
 use std::path::PathBuf;
-use std::process::Command;
-use std::sync::mpsc::channel;
-use std::time::Duration;
 use tempfile::TempDir;
 use tokio::runtime::Runtime;
 
 const DEFAULT_PORT: u16 = 16500;
-// 0.2 is somewhat arbitrarily chosen.
-const WATCHER_DELAY_SECS: f32 = 0.2;
 
 #[derive(Debug, Parser)]
 pub(crate) struct Preview {
     /// The crate to preview
-    project: PathBuf,
+    crate_dir: PathBuf,
     /// The port to serve the preview on.
     #[clap(short, long)]
     port: Option<u16>,
@@ -30,129 +24,16 @@ impl Preview {
 
         let port = self.port.unwrap_or(DEFAULT_PORT);
 
-        let (tx, rx) = channel();
-
-        let mut watcher = watcher(tx, Duration::from_secs_f32(WATCHER_DELAY_SECS)).unwrap();
-
-        watcher
-            .watch(&self.project, RecursiveMode::Recursive)
-            .unwrap();
-
         let server_config = ServerConfig {
             port,
-            assets_dir: outdir.clone(),
-            wasm_file_name: format!("{}_bg.wasm", &self.project_library_name()),
-            javascript_file_name: format!("{}.js", &self.project_library_name()),
+            crate_dir: self.crate_dir,
+            target_dir: self.target,
+            out_dir: outdir.clone(),
         };
 
-        let _preview_server_thread = std::thread::spawn(move || {
-            let runtime = Runtime::new().unwrap();
-            runtime.block_on(async move { start_server(server_config).await });
-        });
+        let runtime = Runtime::new().unwrap();
+        runtime.block_on(async move { start_server(server_config).await });
 
-        self.build(&outdir)?;
-
-        loop {
-            let event = rx.recv()?;
-
-            match event {
-                DebouncedEvent::NoticeWrite(_)
-                | DebouncedEvent::NoticeRemove(_)
-                | DebouncedEvent::Create(_)
-                | DebouncedEvent::Write(_)
-                | DebouncedEvent::Remove(_)
-                | DebouncedEvent::Rename(_, _) => {
-                    self.build(&outdir)?;
-                }
-                DebouncedEvent::Rescan | DebouncedEvent::Chmod(_) => {
-                    // Nothing to do...
-                }
-                DebouncedEvent::Error(err, _) => {
-                    return Err(err)?;
-                }
-            }
-        }
-    }
-
-    fn build(&self, outdir: &PathBuf) -> anyhow::Result<()> {
-        println!("Rebuilding project.");
-        build(
-            &self.project,
-            &self.project_library_name(),
-            &self.target,
-            &outdir,
-        )
-    }
-
-    // some-crate -> some_crate
-    fn project_library_name(&self) -> String {
-        let project_name = self.project.file_name().unwrap().to_str().unwrap();
-        project_name.replace("-", "_")
-    }
-}
-
-fn build(
-    project_dir: &PathBuf,
-    project_library_name: &str,
-    target_dir: &PathBuf,
-    out_dir: &PathBuf,
-) -> anyhow::Result<()> {
-    cargo_build(project_dir, target_dir)?;
-    wasm_bindgen_build(project_library_name, target_dir, out_dir)
-}
-
-fn cargo_build(project_dir: &PathBuf, target_dir: &PathBuf) -> anyhow::Result<()> {
-    let mut cmd = Command::new("cargo");
-
-    let output = cmd
-        .arg("build")
-        .args(&[
-            "--manifest-path",
-            project_dir.join("Cargo.toml").to_str().unwrap(),
-        ])
-        .args(&["--target", "wasm32-unknown-unknown"])
-        .args(&["--features", "preview"])
-        .env("CARGO_TARGET_DIR", target_dir)
-        .spawn()?
-        .wait_with_output()?;
-
-    if output.status.success() {
         Ok(())
-    } else {
-        return Err(anyhow::anyhow!(
-            "{}",
-            String::from_utf8(output.stderr).unwrap()
-        ));
-    }
-}
-
-fn wasm_bindgen_build(
-    project_library_name: &str,
-    target: &PathBuf,
-    out_dir: &PathBuf,
-) -> anyhow::Result<()> {
-    let wasm_path = target.join(format!(
-        "wasm32-unknown-unknown/debug/{}.wasm",
-        project_library_name
-    ));
-
-    let mut cmd = Command::new("wasm-bindgen");
-
-    let output = cmd
-        .arg(wasm_path)
-        .arg("--no-typescript")
-        .args(&["--target", "web"])
-        .args(&["--out-dir", out_dir.to_str().unwrap()])
-        .arg("--debug")
-        .spawn()?
-        .wait_with_output()?;
-
-    if output.status.success() {
-        Ok(())
-    } else {
-        return Err(anyhow::anyhow!(
-            "{}",
-            String::from_utf8(output.stderr).unwrap()
-        ));
     }
 }

--- a/crates/percy-preview-server/Cargo.toml
+++ b/crates/percy-preview-server/Cargo.toml
@@ -4,8 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1"
 axum = {version = "0.5", features = ["headers", "ws"]}
 headers = "0.3"
+notify = "4"
 tokio = {version = "1", features = ["full"]}
 tracing = "0.1"
 tracing-subscriber = {version = "0.3", features = ["env-filter"]}

--- a/crates/percy-preview-server/src/config.rs
+++ b/crates/percy-preview-server/src/config.rs
@@ -4,10 +4,10 @@ use std::path::PathBuf;
 pub struct ServerConfig {
     /// The port to listen on.
     pub port: u16,
-    /// THe directory where the wasm file and JS file live.
-    pub assets_dir: PathBuf,
-    /// The name of the application's wasm file.
-    pub wasm_file_name: String,
-    /// The name of the application's wasm-bindgen auto-generated JavaScript file.
-    pub javascript_file_name: String,
+    /// The crate to preview.
+    pub crate_dir: PathBuf,
+    /// The target directory to use as the CARGO_TARGET_DIR when building the previewed crate.
+    pub target_dir: PathBuf,
+    /// The directory where the wasm file and JS file live.
+    pub out_dir: PathBuf,
 }

--- a/crates/percy-preview-server/src/filesystem_watcher.rs
+++ b/crates/percy-preview-server/src/filesystem_watcher.rs
@@ -1,0 +1,162 @@
+use crate::WebsocketConnections;
+use axum::extract::ws::Message;
+use notify::{watcher, DebouncedEvent, RecursiveMode, Watcher};
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::mpsc::{channel, Receiver, RecvError, SendError, Sender};
+use std::time::Duration;
+
+// 0.2 is somewhat arbitrarily chosen.
+const WATCHER_DELAY_SECS: f32 = 0.2;
+
+pub(crate) struct NotificationSenderConfig {
+    pub crate_dir: PathBuf,
+    pub target_dir: PathBuf,
+    pub out_dir: PathBuf,
+    pub refresh_tx: Sender<()>,
+}
+
+pub(crate) struct NotificationReceiverConfig {
+    pub connections: WebsocketConnections,
+    pub refresh_rx: Receiver<()>,
+}
+
+pub(crate) fn start_fs_notification_sender_thread(
+    config: NotificationSenderConfig,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        let (tx, rx) = channel();
+        let mut watcher = watcher(tx, Duration::from_secs_f32(WATCHER_DELAY_SECS)).unwrap();
+
+        watcher
+            .watch(&config.crate_dir, RecursiveMode::Recursive)
+            .unwrap();
+
+        build(&config.crate_dir, &config.target_dir, &config.out_dir);
+
+        loop {
+            let event = rx.recv().unwrap();
+
+            match event {
+                DebouncedEvent::NoticeWrite(_)
+                | DebouncedEvent::NoticeRemove(_)
+                | DebouncedEvent::Create(_)
+                | DebouncedEvent::Write(_)
+                | DebouncedEvent::Remove(_)
+                | DebouncedEvent::Rename(_, _) => {
+                    match build(&config.crate_dir, &config.target_dir, &config.out_dir) {
+                        Ok(_) => {
+                            match config.refresh_tx.send(()) {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    eprintln!("{}", e);
+                                }
+                            };
+                        }
+                        Err(err) => {
+                            eprintln!("{}", err)
+                        }
+                    }
+                }
+                DebouncedEvent::Rescan | DebouncedEvent::Chmod(_) | DebouncedEvent::Error(_, _) => {
+                    // Nothing to do...
+                }
+            }
+        }
+    })
+}
+
+pub(crate) fn start_fs_notification_receiver_thread(config: NotificationReceiverConfig) {
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async move {
+            while let recv = config.refresh_rx.recv() {
+                match config.refresh_rx.recv() {
+                    Ok(_) => {
+                        let mut connections = config.connections.connections.lock().unwrap();
+
+                        let mut idx = 0;
+                        while idx < connections.len() {
+                            match connections[idx].send(Message::Binary(vec![1, 2, 3])).await {
+                                Ok(_) => {
+                                    idx += 1;
+                                }
+                                Err(_) => {
+                                    connections.remove(idx);
+                                }
+                            };
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("{}", e);
+                        return;
+                    }
+                };
+            }
+        });
+    });
+}
+
+fn build(crate_dir: &PathBuf, target_dir: &PathBuf, out_dir: &PathBuf) -> anyhow::Result<()> {
+    let project_library_name = crate_dir.file_name().unwrap().to_str().unwrap();
+    let project_library_name = project_library_name.replace("-", "_");
+
+    cargo_build(crate_dir, target_dir)?;
+    wasm_bindgen_build(&project_library_name, target_dir, out_dir)
+}
+
+fn cargo_build(project_dir: &PathBuf, target_dir: &PathBuf) -> anyhow::Result<()> {
+    let mut cmd = Command::new("cargo");
+
+    let output = cmd
+        .arg("build")
+        .args(&[
+            "--manifest-path",
+            project_dir.join("Cargo.toml").to_str().unwrap(),
+        ])
+        .args(&["--target", "wasm32-unknown-unknown"])
+        .args(&["--features", "preview"])
+        .env("CARGO_TARGET_DIR", target_dir)
+        .spawn()?
+        .wait_with_output()?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        return Err(anyhow::anyhow!(
+            "{}",
+            String::from_utf8(output.stderr).unwrap()
+        ));
+    }
+}
+
+fn wasm_bindgen_build(
+    project_library_name: &str,
+    target: &PathBuf,
+    out_dir: &PathBuf,
+) -> anyhow::Result<()> {
+    let wasm_path = target.join(format!(
+        "wasm32-unknown-unknown/debug/{}.wasm",
+        project_library_name
+    ));
+
+    let mut cmd = Command::new("wasm-bindgen");
+
+    let output = cmd
+        .arg(wasm_path)
+        .arg("--no-typescript")
+        .args(&["--target", "web"])
+        .args(&["--out-dir", out_dir.to_str().unwrap()])
+        .arg("--debug")
+        .spawn()?
+        .wait_with_output()?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        return Err(anyhow::anyhow!(
+            "{}",
+            String::from_utf8(output.stderr).unwrap()
+        ));
+    }
+}

--- a/crates/percy-preview-server/src/router/websocket.rs
+++ b/crates/percy-preview-server/src/router/websocket.rs
@@ -1,7 +1,19 @@
+use crate::websocket::WebsocketConnections;
+use axum::extract::WebSocketUpgrade;
 use axum::response::IntoResponse;
+use axum::Extension;
 
 pub(crate) const WEBSOCKET_ROUTE: &'static str = "/ws";
 
-pub(crate) async fn websocket_handler() -> impl IntoResponse {
-    unimplemented!()
+pub(crate) async fn websocket_handler(
+    ws: WebSocketUpgrade,
+    Extension(websocket_connections): Extension<WebsocketConnections>,
+) -> impl IntoResponse {
+    ws.on_upgrade(|socket| async move {
+        websocket_connections
+            .connections
+            .lock()
+            .unwrap()
+            .push(socket);
+    })
 }

--- a/crates/percy-preview-server/src/websocket.rs
+++ b/crates/percy-preview-server/src/websocket.rs
@@ -1,0 +1,7 @@
+use axum::extract::ws::WebSocket;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Default)]
+pub(crate) struct WebsocketConnections {
+    pub(crate) connections: Arc<Mutex<Vec<WebSocket>>>,
+}

--- a/examples/component-preview/src/views/controls_header/controls_header_view.rs
+++ b/examples/component-preview/src/views/controls_header/controls_header_view.rs
@@ -5,7 +5,9 @@ pub struct ControlsHeaderView {}
 impl View for ControlsHeaderView {
     fn render(&self) -> VirtualNode {
         html! {
-            <div> This is the component where you can control things like pausing the watcher </div>
+            <div>
+               This will be a controls component where you can control things like pausing the watcher.
+            </div>
         }
     }
 }


### PR DESCRIPTION
This commit makes it so that the Percy Preview App refreshes whenever
the crate that is being previewed changes.

This helps your components live reload as you work.

We're quickly throwing some code together to feel out the experience.
