### PR TITLE
Support routing in preview app

### DIFF
--- a/crates/percy-dom/Cargo.toml
+++ b/crates/percy-dom/Cargo.toml
@@ -23,13 +23,16 @@ features = [
     "Document",
     "Element",
     "EventTarget",
+    "History",
     "HtmlCollection",
     "HtmlElement",
     "HtmlInputElement",
     "HtmlTextAreaElement",
+    "Location",
     "Node",
     "NodeList",
     "Text",
+    "Url",
     "Window",
 ]
 

--- a/crates/percy-dom/src/lib.rs
+++ b/crates/percy-dom/src/lib.rs
@@ -26,6 +26,7 @@ mod patch;
 mod pdom;
 
 pub mod render;
+pub mod single_page_app;
 
 /// Exports structs and macros that you'll almost always want access to in a virtual-dom
 /// powered application

--- a/crates/percy-dom/src/pdom/events.rs
+++ b/crates/percy-dom/src/pdom/events.rs
@@ -24,7 +24,7 @@ impl PercyDom {
         let callback = Closure::wrap(callback);
 
         self.root_node
-            .add_event_listener_with_callback(event, callback.as_ref().as_ref().unchecked_ref())
+            .add_event_listener_with_callback(event, callback.as_ref().unchecked_ref())
             .unwrap();
 
         self.event_delegation_listeners

--- a/crates/percy-dom/src/single_page_app.rs
+++ b/crates/percy-dom/src/single_page_app.rs
@@ -1,0 +1,80 @@
+//! Utilities for single page applications.
+
+use js_sys::Reflect;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
+use web_sys::Url;
+
+/// Ensures that anytime a link such as `<a href="/foo" />` is clicked we call the provided
+/// callback with "/foo".
+pub fn intercept_relative_links<F: FnMut(String) -> () + 'static>(mut on_anchor_tag_click: F) {
+    let on_anchor_click = move |event: web_sys::Event| {
+
+        // Get the tag name of the element that was clicked
+        let target = event
+            .target()
+            .unwrap()
+            .dyn_into::<web_sys::Element>()
+            .unwrap();
+        let tag_name = target.tag_name();
+        let tag_name = tag_name.as_str();
+
+        // If the clicked element is an anchor tag, check if it points to the current website
+        // (ex: '<a href="/some-page"></a>'
+        if tag_name.to_lowercase() == "a" {
+            let link = Reflect::get(&target, &"href".into())
+                .unwrap()
+                .as_string()
+                .unwrap();
+            let link_url = Url::new(link.as_str()).unwrap();
+
+            // If this was indeed a relative URL, let our single page application router
+            // handle it
+            if link_url.hostname() == hostname() && link_url.port() == port() {
+                event.prevent_default();
+
+                on_anchor_tag_click(link_url.pathname())
+            }
+        }
+    };
+    let on_anchor_click = Closure::wrap(Box::new(on_anchor_click) as Box<dyn FnMut(_)>);
+
+    window()
+        .add_event_listener_with_callback("click", on_anchor_click.as_ref().unchecked_ref())
+        .unwrap();
+    on_anchor_click.forget();
+}
+
+/// Set a function to be called with the new path whenever a popstate event occurs on the window.
+pub fn set_onpopstate_handler<F: FnMut(String) -> () + 'static>(mut on_new_path: F) {
+    let on_popstate = move |_: web_sys::Event| {
+        let location = location();
+        let path = location.pathname().unwrap() + &location.search().unwrap();
+
+        on_new_path(path)
+    };
+    let on_popstate = Box::new(on_popstate) as Box<dyn FnMut(_)>;
+    let on_popstate = Closure::wrap(on_popstate);
+    window().set_onpopstate(Some(on_popstate.as_ref().unchecked_ref()));
+    on_popstate.forget();
+}
+
+fn window() -> web_sys::Window {
+    web_sys::window().unwrap()
+}
+
+fn document() -> web_sys::Document {
+    window().document().unwrap()
+}
+
+fn location() -> web_sys::Location {
+    document().location().unwrap()
+}
+
+fn hostname() -> String {
+    location().hostname().unwrap()
+}
+
+fn port() -> String {
+    location().port().unwrap()
+}

--- a/crates/percy-preview-app/src/app.rs
+++ b/crates/percy-preview-app/src/app.rs
@@ -1,15 +1,17 @@
 use std::sync::{Arc, Mutex};
 
-use crate::create_router;
 use app_world::AppWorldWrapper;
+
+use crate::create_router;
+
+pub(crate) use self::config::AppConfig;
+pub use self::world::async_task_spawner;
+use self::world::{create_world, WorldConfig};
+pub(crate) use self::world::{Msg, World};
 
 mod config;
 
-pub use self::config::AppConfig;
-
 mod world;
-pub(crate) use self::world::World;
-use self::world::{create_world, Msg, WorldConfig};
 
 /// Powers an application that can be used to preview view components.
 pub(crate) struct PercyPreviewApp {
@@ -22,13 +24,15 @@ impl PercyPreviewApp {
         let router = create_router();
 
         let world = create_world(WorldConfig {
+            async_task_spawner: config.async_task_spawner,
+            after_path_change: config.after_path_change,
             previews: config.previews,
             render,
             router,
         });
         let world = AppWorldWrapper::new(world);
 
-        world.msg(Msg::ProvideRouteData);
+        world.msg(Msg::AttachRouteDataProvider);
 
         Self { world }
     }

--- a/crates/percy-preview-app/src/app/world.rs
+++ b/crates/percy-preview-app/src/app/world.rs
@@ -4,6 +4,7 @@ pub use self::message::*;
 use std::ops::Deref;
 
 mod world_config;
+pub use self::resources::async_task_spawner;
 use self::resources::Resources;
 use self::state::State;
 pub(super) use self::world_config::WorldConfig;
@@ -19,10 +20,15 @@ pub(crate) struct World {
 pub(super) fn create_world(config: WorldConfig) -> World {
     World {
         state: State {
+            rendering_enabled: true,
+            active_path: "/".to_string(),
             previews: config.previews,
         },
         resources: Resources {
+            after_path_change: config.after_path_change,
+            render_fn: config.render,
             router: config.router,
+            async_task_spawner: config.async_task_spawner,
         },
     }
 }

--- a/crates/percy-preview-app/src/app/world/message.rs
+++ b/crates/percy-preview-app/src/app/world/message.rs
@@ -4,5 +4,8 @@ mod message_handlers;
 ///
 /// For example, a Msg might get sent when a button is clicked.
 pub enum Msg {
-    ProvideRouteData,
+    /// Attach the route data provider to the router.
+    AttachRouteDataProvider,
+    /// Set the active URL path, such as "/some/path".
+    SetPath(String),
 }

--- a/crates/percy-preview-app/src/app/world/message/message_handlers.rs
+++ b/crates/percy-preview-app/src/app/world/message/message_handlers.rs
@@ -3,6 +3,7 @@ use crate::app::World;
 use app_world::AppWorld;
 use app_world::AppWorldWrapper;
 
+mod set_path_message_handler;
 mod set_route_data_provider_message_handler;
 
 impl AppWorld for World {
@@ -10,7 +11,17 @@ impl AppWorld for World {
 
     fn msg(&mut self, message: Self::Message, wrap: AppWorldWrapper<Self>) {
         match message {
-            Msg::ProvideRouteData => self.set_route_data_provider_message_handler(wrap),
+            Msg::AttachRouteDataProvider => self.set_route_data_provider_message_handler(wrap),
+            Msg::SetPath(new_path) => {
+                self.set_path_message_handler(new_path, wrap);
+            }
+        };
+
+        if self.state.rendering_enabled {
+            let render_fn = self.resources.render_fn.clone();
+            self.resources
+                .async_task_spawner
+                .spawn(Box::pin(async move { (render_fn.lock().unwrap())() }));
         }
     }
 }

--- a/crates/percy-preview-app/src/app/world/message/message_handlers/set_path_message_handler.rs
+++ b/crates/percy-preview-app/src/app/world/message/message_handlers/set_path_message_handler.rs
@@ -1,0 +1,33 @@
+use app_world::AppWorldWrapper;
+
+use crate::app::World;
+
+impl World {
+    pub(super) fn set_path_message_handler(
+        &mut self,
+        new_path: String,
+        wrap: AppWorldWrapper<Self>,
+    ) {
+        let active_path = &self.state.active_path;
+
+        if &new_path == active_path {
+            return;
+        }
+
+        self.state.active_path = new_path.clone();
+        (self.resources.after_path_change)(&new_path);
+
+        self.resources
+            .async_task_spawner
+            .spawn(Box::pin(async move {
+                if let Some(route) = wrap
+                    .read()
+                    .resources
+                    .router
+                    .matching_route_handler(&new_path)
+                {
+                    route.on_visit(&new_path);
+                }
+            }));
+    }
+}

--- a/crates/percy-preview-app/src/app/world/resources.rs
+++ b/crates/percy-preview-app/src/app/world/resources.rs
@@ -1,7 +1,21 @@
+use crate::async_task_spawner::AsyncTaskSpawner;
 use percy_router::prelude::Router;
+use std::sync::{Arc, Mutex};
+
+/// A function used to re-render the application.
+pub type RenderFn = Arc<Mutex<Box<dyn FnMut() -> ()>>>;
+
+pub mod async_task_spawner;
 
 /// Application resources.
-pub struct Resources {
+pub(crate) struct Resources {
+    /// A function to call whenever the application's URL path changes.
+    /// Such as when we visit `/components/component-name`
+    pub after_path_change: Box<dyn FnMut(&str) -> ()>,
+    /// See [`AsyncTaskSpawner`]
+    pub async_task_spawner: Arc<dyn AsyncTaskSpawner>,
     /// See [`Router`]
-    pub(crate) router: Router,
+    pub router: Router,
+    /// See [`RenderFn`]
+    pub render_fn: RenderFn,
 }

--- a/crates/percy-preview-app/src/app/world/resources/async_task_spawner.rs
+++ b/crates/percy-preview-app/src/app/world/resources/async_task_spawner.rs
@@ -1,0 +1,19 @@
+//! Spawn async tasks.
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// Used to run an async function.
+///
+/// In the browser this will typically schedule the future to be called on the next tick of
+/// the JS microtask queue.
+///
+/// Outside of JS this will often spawn the task in a thread.
+pub trait AsyncTaskSpawner: Send + Sync {
+    /// Run an async function, typically in another thread or, if in the browser, on another tick
+    /// of the JS event loop.
+    fn spawn(&self, task: AsyncFnToSpawn);
+}
+
+/// The async task to run.
+pub type AsyncFnToSpawn = Pin<Box<dyn Future<Output = ()> + 'static>>;

--- a/crates/percy-preview-app/src/app/world/state.rs
+++ b/crates/percy-preview-app/src/app/world/state.rs
@@ -2,5 +2,7 @@ use percy_preview::Preview;
 
 /// Application state.
 pub(crate) struct State {
-    pub(crate) previews: Vec<Preview>,
+    pub rendering_enabled: bool,
+    pub active_path: String,
+    pub previews: Vec<Preview>,
 }

--- a/crates/percy-preview-app/src/app/world/world_config.rs
+++ b/crates/percy-preview-app/src/app/world/world_config.rs
@@ -1,8 +1,14 @@
+use crate::async_task_spawner::AsyncTaskSpawner;
 use percy_preview::Preview;
 use percy_router::prelude::Router;
 use std::sync::{Arc, Mutex};
 
 pub(crate) struct WorldConfig {
+    /// See [`AsyncTaskSpawner`]
+    pub async_task_spawner: Arc<dyn AsyncTaskSpawner>,
+    /// A function to call whenever the application's URL path changes.
+    /// Such as when we visit `/components/component-name`
+    pub(crate) after_path_change: Box<dyn FnMut(&str) -> ()>,
     /// All of the view components that can be previewed.
     pub previews: Vec<Preview>,
     /// Used to re-render the application into the DOM.

--- a/crates/percy-preview-app/src/config.rs
+++ b/crates/percy-preview-app/src/config.rs
@@ -2,13 +2,10 @@ use crate::async_task_spawner::AsyncTaskSpawner;
 use percy_preview::Preview;
 use std::sync::Arc;
 
-/// Configuration for a PercyPreviewApp.
-pub(crate) struct AppConfig {
+/// Configuration for the Percy Preview web client.
+pub struct WebClientConfig {
     /// See [`AsyncTaskSpawner`]
     pub async_task_spawner: Arc<dyn AsyncTaskSpawner>,
-    /// A function to call whenever the application's URL path changes.
-    /// Such as when we visit `/components/component-name`
-    pub after_path_change: Box<dyn FnMut(&str) -> ()>,
     /// All of the view components previews.
     pub previews: Vec<Preview>,
 }

--- a/crates/percy-preview-app/src/lib.rs
+++ b/crates/percy-preview-app/src/lib.rs
@@ -5,19 +5,26 @@
 #[macro_use]
 extern crate sunbeam;
 
-pub use self::app::AppConfig;
 use self::app::PercyPreviewApp;
 use self::render::render_app;
 use std::sync::{Arc, Mutex};
 
+pub use self::app::async_task_spawner;
+use crate::app::AppConfig;
+pub use crate::config::WebClientConfig;
+use crate::window_messenger::WindowMessenger;
+use percy_dom::single_page_app::{intercept_relative_links, set_onpopstate_handler};
 use percy_dom::{render::create_render_scheduler, PercyDom, VirtualNode};
 use routes::create_router;
 use wasm_bindgen::prelude::*;
 
 mod app;
+mod config;
 mod render;
 mod routes;
 mod view;
+
+mod window_messenger;
 
 pub mod all_sunbeam_css;
 
@@ -31,13 +38,16 @@ pub struct PercyPreviewWebClient {
 
 impl PercyPreviewWebClient {
     /// Create a new preview application and append the application to a DOM node.
-    pub fn new_append_to_mount(config: AppConfig, dom_selector_of_mount: &str) -> Self {
+    pub fn new_append_to_mount(config: WebClientConfig, dom_selector_of_mount: &str) -> Self {
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
         let render: Arc<Mutex<Box<dyn FnMut() -> ()>>> = Arc::new(Mutex::new(Box::new(|| {})));
         let render_clone = Arc::clone(&render);
 
-        let app = PercyPreviewApp::new(config, render);
+        let app = create_app(config, render);
+
+        let window_messenger = WindowMessenger::new(app.world.clone());
+        setup_single_page_application(window_messenger);
 
         let pdom = create_percy_dom(dom_selector_of_mount, render_app(&app.world));
 
@@ -52,14 +62,55 @@ impl PercyPreviewWebClient {
     }
 }
 
-fn create_percy_dom(dom_selector_of_mount: &str, start_view: VirtualNode) -> PercyDom {
-    let window = web_sys::window().unwrap();
-    let document = window.document().unwrap();
+fn create_app(
+    config: WebClientConfig,
+    render: Arc<Mutex<Box<dyn FnMut() -> ()>>>,
+) -> PercyPreviewApp {
+    PercyPreviewApp::new(
+        AppConfig {
+            async_task_spawner: config.async_task_spawner,
+            after_path_change: Box::new(|new_path| {
+                history()
+                    .push_state_with_url(&JsValue::null(), "Percy Preview App", Some(new_path))
+                    .unwrap();
+            }),
+            previews: config.previews,
+        },
+        render,
+    )
+}
 
-    let mount = document
+fn setup_single_page_application(window_messenger: WindowMessenger) {
+    window_messenger.msg_set_path(window().location().pathname().unwrap().to_string());
+
+    let wm1 = window_messenger.clone();
+    let wm2 = window_messenger;
+
+    intercept_relative_links(move |new_path| {
+        wm1.msg_set_path(new_path);
+    });
+    set_onpopstate_handler(move |new_path| {
+        wm2.msg_set_path(new_path);
+    });
+}
+
+fn create_percy_dom(dom_selector_of_mount: &str, start_view: VirtualNode) -> PercyDom {
+    let mount = document()
         .query_selector(dom_selector_of_mount)
         .unwrap()
         .unwrap();
     let pdom = PercyDom::new_append_to_mount(start_view, &mount);
     pdom
+}
+
+fn window() -> web_sys::Window {
+    web_sys::window().unwrap()
+}
+
+fn document() -> web_sys::Document {
+    window().document().unwrap()
+}
+
+fn history() -> web_sys::History {
+    window().history().unwrap()
 }

--- a/crates/percy-preview-app/src/render.rs
+++ b/crates/percy-preview-app/src/render.rs
@@ -3,9 +3,9 @@ use app_world::AppWorldWrapper;
 use percy_dom::prelude::*;
 
 pub(super) fn render_app(app: &AppWorldWrapper<World>) -> VirtualNode {
-    let path = "/";
+    let path = app.read().active_path.clone();
 
-    let view = app.read().resources.router.view(path);
+    let view = app.read().resources.router.view(&path);
 
     if let Some(view) = view {
         view

--- a/crates/percy-preview-app/src/routes.rs
+++ b/crates/percy-preview-app/src/routes.rs
@@ -5,7 +5,10 @@ use percy_router::prelude::*;
 pub(crate) fn create_router() -> Router {
     use crate::view;
 
-    let router = Router::new(create_routes![view::index_route::render_index_route]);
+    let router = Router::new(create_routes![
+        view::index_route::render_index_route,
+        view::visualize_component_route::render_visualize_component_route,
+    ]);
 
     router
 }

--- a/crates/percy-preview-app/src/view.rs
+++ b/crates/percy-preview-app/src/view.rs
@@ -1,1 +1,2 @@
 pub mod index_route;
+pub mod visualize_component_route;

--- a/crates/percy-preview-app/src/window_messenger.rs
+++ b/crates/percy-preview-app/src/window_messenger.rs
@@ -1,0 +1,17 @@
+use crate::app::{Msg, World};
+use app_world::AppWorldWrapper;
+
+#[derive(Clone)]
+pub(crate) struct WindowMessenger {
+    world: AppWorldWrapper<World>,
+}
+
+impl WindowMessenger {
+    pub fn new(world: AppWorldWrapper<World>) -> Self {
+        Self { world }
+    }
+
+    pub fn msg_set_path(&self, new_path: String) {
+        self.world.msg(Msg::SetPath(new_path))
+    }
+}

--- a/crates/percy-preview/src/lib.rs
+++ b/crates/percy-preview/src/lib.rs
@@ -18,7 +18,7 @@ pub struct Preview {
     /// A url friendly version of the name.
     name_url_friendly: UrlFriendlyString,
     /// Render the preview
-    render: Rc<RefCell<dyn FnMut() -> VirtualNode>>,
+    renderer: Rc<RefCell<dyn FnMut() -> VirtualNode>>,
 }
 
 /// A string that only contains letters, numbers, hyphens and underscores.
@@ -31,7 +31,7 @@ impl Preview {
         Preview {
             name: name.to_string(),
             name_url_friendly,
-            render,
+            renderer: render,
         }
     }
 
@@ -45,9 +45,9 @@ impl Preview {
         &self.name_url_friendly.0
     }
 
-    /// Render the preview.
-    pub fn render(&self) -> &Rc<RefCell<dyn FnMut() -> VirtualNode>> {
-        &self.render
+    /// Returns a function that can be used to render the preview.
+    pub fn renderer(&self) -> &Rc<RefCell<dyn FnMut() -> VirtualNode>> {
+        &self.renderer
     }
 }
 

--- a/crates/percy-preview/src/rerender.rs
+++ b/crates/percy-preview/src/rerender.rs
@@ -17,7 +17,7 @@ pub struct Rerender {
 
 impl Rerender {
     /// Create a new Rerender
-    pub fn new(render: Render) -> Self {
+    pub fn new() -> Self {
         Rerender {
             render: Arc::new(Mutex::new(Box::new(|| {}))),
         }

--- a/examples/component-preview/Cargo.toml
+++ b/examples/component-preview/Cargo.toml
@@ -21,6 +21,7 @@ js-sys = "0.3"
 percy-dom = {path = "../../crates/percy-dom"}
 sunbeam = "0.0.3-alpha"
 wasm-bindgen = "0.2.80"
+wasm-bindgen-futures = "0.4"
 
 # Optional dependencies
 percy-preview = {optional = true, path = "../../crates/percy-preview"}

--- a/examples/component-preview/README.md
+++ b/examples/component-preview/README.md
@@ -3,6 +3,9 @@
 An example of how to use `percy-preview` in order to preview your application's view components.
 
 ```
+git clone git@github.com:chinedufn/percy.git
+cd percy
+
 cargo install percy-cli
-percy preview examples/component-preview
+percy preview examples/component-preview --target target/preview
 ```

--- a/examples/component-preview/src/async_task_spawner.rs
+++ b/examples/component-preview/src/async_task_spawner.rs
@@ -1,0 +1,9 @@
+use percy_preview_app::async_task_spawner::{AsyncFnToSpawn, AsyncTaskSpawner};
+
+pub struct WebAsyncTaskSpawner;
+
+impl AsyncTaskSpawner for WebAsyncTaskSpawner {
+    fn spawn(&self, task: AsyncFnToSpawn) {
+        wasm_bindgen_futures::spawn_local(task)
+    }
+}

--- a/examples/component-preview/src/lib.rs
+++ b/examples/component-preview/src/lib.rs
@@ -1,4 +1,4 @@
-//! Used to run the photomules-app in a browser.
+//! Used to run the component-preview-app in a browser.
 
 #![deny(missing_docs)]
 
@@ -12,6 +12,8 @@ use std::sync::{Arc, Mutex};
 use crate::routes::render_active_route;
 use wasm_bindgen::prelude::*;
 
+mod async_task_spawner;
+
 #[cfg(feature = "preview")]
 mod preview;
 #[cfg(feature = "preview")]
@@ -19,15 +21,15 @@ pub use self::preview::start_component_preview;
 mod routes;
 mod views;
 
-/// Photomules' dashboard web client
+/// Component Preview dashboard web client
 #[wasm_bindgen]
-pub struct PhotomulesWebClient;
+pub struct ComponentPreviewWebClient;
 
 #[wasm_bindgen]
-impl PhotomulesWebClient {
+impl ComponentPreviewWebClient {
     /// Create a new instance of the web client application.
     #[wasm_bindgen(constructor)]
-    pub fn new(dom_selector_of_mount: &str) -> PhotomulesWebClient {
+    pub fn new(dom_selector_of_mount: &str) -> ComponentPreviewWebClient {
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
 
         let mut pdom = create_percy_dom(dom_selector_of_mount);
@@ -41,7 +43,7 @@ impl PhotomulesWebClient {
 
         *render_clone.lock().unwrap() = render;
 
-        PhotomulesWebClient
+        ComponentPreviewWebClient
     }
 }
 

--- a/examples/component-preview/src/preview.rs
+++ b/examples/component-preview/src/preview.rs
@@ -1,27 +1,39 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use wasm_bindgen::prelude::*;
 
+use crate::async_task_spawner::WebAsyncTaskSpawner;
 use percy_preview::{Preview, Rerender};
-use percy_preview_app::{AppConfig, PercyPreviewWebClient};
+use percy_preview_app::{PercyPreviewWebClient, WebClientConfig};
 
 /// All of the view components to preview.
 fn previews(rerender: Rerender) -> Vec<Preview> {
     use crate::views;
 
-    vec![views::login::preview::login_form_preview(rerender)]
+    vec![
+        views::login::preview::login_form_preview(rerender.clone()),
+        views::side_nav::preview::side_nav_preview(rerender.clone()),
+    ]
 }
 
 /// Start the Percy preview application.
 #[wasm_bindgen]
-pub fn start_component_preview(dom_selector_of_mount: &str) {
-    let rerender = Rerender::new(Arc::new(Mutex::new(Box::new(move || {}))));
+pub fn start_component_preview(dom_selector_of_mount: &str) -> PercyPreviewWebClient {
+    let rerender = Rerender::new();
 
     let rerender_clone = rerender.clone();
 
     let previews = previews(rerender);
 
-    let client =
-        PercyPreviewWebClient::new_append_to_mount(AppConfig { previews }, dom_selector_of_mount);
+    let client = PercyPreviewWebClient::new_append_to_mount(
+        WebClientConfig {
+            async_task_spawner: Arc::new(WebAsyncTaskSpawner),
+            previews,
+        },
+        dom_selector_of_mount,
+    );
 
-    rerender_clone.set_render_fn(Box::new(move || (client.rerender.lock().unwrap())()));
+    let rerender = client.rerender.clone();
+    rerender_clone.set_render_fn(Box::new(move || (rerender.lock().unwrap())()));
+
+    client
 }

--- a/examples/component-preview/src/views.rs
+++ b/examples/component-preview/src/views.rs
@@ -1,1 +1,2 @@
 pub mod login;
+pub mod side_nav;

--- a/examples/component-preview/src/views/login/login_form_view.rs
+++ b/examples/component-preview/src/views/login/login_form_view.rs
@@ -34,6 +34,6 @@ pub mod preview {
             }
         };
 
-        Preview::new("Login Form View", Rc::new(RefCell::new(render)))
+        Preview::new("Login Form", Rc::new(RefCell::new(render)))
     }
 }

--- a/examples/component-preview/src/views/side_nav.rs
+++ b/examples/component-preview/src/views/side_nav.rs
@@ -1,0 +1,3 @@
+pub use self::side_nav_view::*;
+
+mod side_nav_view;

--- a/examples/component-preview/src/views/side_nav/side_nav_view.rs
+++ b/examples/component-preview/src/views/side_nav/side_nav_view.rs
@@ -1,0 +1,40 @@
+use percy_dom::prelude::*;
+
+pub struct SideNavView {}
+
+impl View for SideNavView {
+    fn render(&self) -> VirtualNode {
+        html! {
+            <div>
+                <div>A side nav with some buttons</div>
+                <div>
+                    <span>First Button</span>
+                </div>
+                <div>
+                    <span>Second Button</span>
+                </div>
+            </div>
+        }
+    }
+}
+
+#[cfg(feature = "preview")]
+pub mod preview {
+    use super::*;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use percy_preview::{Preview, Rerender};
+
+    pub fn side_nav_preview(_rerender: Rerender) -> Preview {
+        let render = move || {
+            let view = SideNavView {};
+
+            html! {
+                <div> { view } </div>
+            }
+        };
+
+        Preview::new("Side Nav", Rc::new(RefCell::new(render)))
+    }
+}


### PR DESCRIPTION
This commit adds routing to the percy preview app.

You can now click on a component's name in the left side nav in order to
preview that component.
