### PR TITLE
Render preview description

### DIFF
--- a/crates/percy-preview-server/src/filesystem_watcher.rs
+++ b/crates/percy-preview-server/src/filesystem_watcher.rs
@@ -33,7 +33,12 @@ pub(crate) fn start_fs_notification_sender_thread(
             .watch(&config.crate_dir, RecursiveMode::Recursive)
             .unwrap();
 
-        build(&config.crate_dir, &config.target_dir, &config.out_dir);
+        match build(&config.crate_dir, &config.target_dir, &config.out_dir) {
+            Ok(_) => {}
+            Err(err) => {
+                eprintln!("{}", err)
+            }
+        };
 
         loop {
             let event = rx.recv().unwrap();

--- a/crates/percy-preview/src/lib.rs
+++ b/crates/percy-preview/src/lib.rs
@@ -15,6 +15,9 @@ mod rerender;
 pub struct Preview {
     /// The name of this preview
     name: String,
+    /// A description of the preview.
+    /// This gets displayed above the preview.
+    description: Option<String>,
     /// A url friendly version of the name.
     name_url_friendly: UrlFriendlyString,
     /// Render the preview
@@ -30,6 +33,7 @@ impl Preview {
         let name_url_friendly = UrlFriendlyString::new(name.to_string());
         Preview {
             name: name.to_string(),
+            description: None,
             name_url_friendly,
             renderer: render,
         }
@@ -43,6 +47,16 @@ impl Preview {
     /// A URL friendly version of the name.
     pub fn name_url_friendly(&self) -> &String {
         &self.name_url_friendly.0
+    }
+
+    /// The preview's description.
+    pub fn description(&self) -> &Option<String> {
+        &self.description
+    }
+
+    /// The preview's description.
+    pub fn set_description(&mut self, description: Option<String>) {
+        self.description = description;
     }
 
     /// Returns a function that can be used to render the preview.

--- a/examples/component-preview/src/views/login/login_form_view.rs
+++ b/examples/component-preview/src/views/login/login_form_view.rs
@@ -34,6 +34,11 @@ pub mod preview {
             }
         };
 
-        Preview::new("Login Form", Rc::new(RefCell::new(render)))
+        let mut preview = Preview::new("Login Form", Rc::new(RefCell::new(render)));
+        preview.set_description(Some(
+            "This is the login form preview's description.".to_string(),
+        ));
+
+        preview
     }
 }


### PR DESCRIPTION
This commit adds a description to the `percy_preview::Preview` type.

This description gets rendered above the component preview.
