### PR TITLE
Add `macro` feature to percy-dom

### DIFF
--- a/crates/percy-dom/Cargo.toml
+++ b/crates/percy-dom/Cargo.toml
@@ -9,11 +9,17 @@ repository = "https://github.com/chinedufn/percy"
 documentation = "https://chinedufn.github.io/percy/api/percy_dom/"
 edition = "2018"
 
+[features]
+default = ["macro"]
+macro = ["html-macro"]
+
 [dependencies]
 js-sys = "0.3"
-wasm-bindgen = "0.2.33"
 virtual-node = { path = "../virtual-node", version = "0.3.2" }
-html-macro = { path = "../html-macro", version = "0.2.1"}
+wasm-bindgen = "0.2.33"
+
+# Optional dependencies
+html-macro = { optional = true, path = "../html-macro", version = "0.2.1"}
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/percy-dom/src/lib.rs
+++ b/crates/percy-dom/src/lib.rs
@@ -13,6 +13,7 @@ pub use wasm_bindgen::JsCast;
 // access to `Closure` when creating event handlers.
 pub use wasm_bindgen::prelude::Closure;
 
+#[cfg(feature = "macro")]
 pub use html_macro::html;
 pub use virtual_node::*;
 
@@ -37,6 +38,7 @@ pub mod prelude {
 
     pub use wasm_bindgen::prelude::Closure;
 
+    #[cfg(feature = "macro")]
     pub use html_macro::html;
     pub use virtual_node::{EventAttribFn, IterableNodes, View};
 


### PR DESCRIPTION
This commit adds a `macro` feature to the percy-dom crate.

The feature can be used to enable/disable the `html-macro`
dependency.

We currently enable this feature by default. This was not a deeply
thought through decision. We're starting with it enabled
to preserve backwards compatibility.
