### PR TITLE
Preserve focusable elements

### DIFF
--- a/crates/percy-dom/src/diff/diff_test_case.rs
+++ b/crates/percy-dom/src/diff/diff_test_case.rs
@@ -1,4 +1,4 @@
-//! Kept in it's own file to more easily import into the Percy book.
+//! Kept in it's own file to more easily import into the Percy book without extra indentation.
 
 use crate::diff::diff;
 use crate::patch::Patch;

--- a/crates/percy-dom/src/diff/longest_increasing_subsequence.rs
+++ b/crates/percy-dom/src/diff/longest_increasing_subsequence.rs
@@ -1,5 +1,7 @@
+use crate::diff::ElementKey;
+
 const PLACEHOLDER_KEY_AND_IDX: KeyAndChildIdx = KeyAndChildIdx {
-    key: "...",
+    key: ElementKey::Explicit("..."),
     child_idx: 123,
 };
 const PLACEHOLDER_USIZE: usize = 55555;
@@ -7,7 +9,7 @@ const PLACEHOLDER_USIZE: usize = 55555;
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(test, derive(Debug))]
 pub(super) struct KeyAndChildIdx<'a> {
-    pub key: &'a str,
+    pub key: ElementKey<'a>,
     pub child_idx: usize,
 }
 
@@ -72,7 +74,7 @@ mod tests {
 
     const fn make_val(key: &'static str, val: usize) -> KeyAndChildIdx {
         KeyAndChildIdx {
-            key,
+            key: ElementKey::Explicit(key),
             child_idx: val,
         }
     }

--- a/crates/percy-dom/src/single_page_app.rs
+++ b/crates/percy-dom/src/single_page_app.rs
@@ -9,7 +9,6 @@ use web_sys::Url;
 /// callback with "/foo".
 pub fn intercept_relative_links<F: FnMut(String) -> () + 'static>(mut on_anchor_tag_click: F) {
     let on_anchor_click = move |event: web_sys::Event| {
-
         // Get the tag name of the element that was clicked
         let target = event
             .target()

--- a/crates/percy-preview-app/build.rs
+++ b/crates/percy-preview-app/build.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::{PathBuf};
+use std::path::PathBuf;
 use sunbeam_build::{files_in_dir_recursive_ending_with, SunbeamConfig};
 
 fn main() {


### PR DESCRIPTION
This commit make our diffing algorithm prefer to moving focusable
elements such as inputs and textareas over removing and recreating them.

This is meant to prevent scenarios where our diff/patch would lead to an
input element losing focus, such as when prepending a sibling element
before an input element.

For example, before this commit the following start and end virtual dom
would lead to us recreating the input element and so it would lose focus.

```
Start: <div> <input /> </div>
End: <div> <br /> <input /> </div>
```

As of this commit the input element will no longer lose focus.

We accomplish this by treating focusable elements such as inputs and
textareas in much the same way that we treat keyed elements, such that
the diffing algorithm attempts to, when possible, move them instead of
recreate them.
