### PR TITLE
Fix indexing when moving nodes

### DIFF
--- a/crates/percy-dom/src/patch/apply_patches.rs
+++ b/crates/percy-dom/src/patch/apply_patches.rs
@@ -75,7 +75,6 @@ pub fn patch<N: Into<Node>>(
         }
     }
 
-    // FIXME: Remove patches as an argument.. just trying to track down a bug..
     overwrite_events(new_vnode, root_events_node, virtual_events);
 
     Ok(())

--- a/crates/virtual-node/src/event/virtual_events.rs
+++ b/crates/virtual-node/src/event/virtual_events.rs
@@ -322,7 +322,7 @@ impl VirtualEventNode {
 
     /// Remove a child node from it's siblings.
     pub fn remove_node_from_siblings(&mut self, child: &Rc<RefCell<VirtualEventNode>>) {
-        let mut child = child.borrow_mut();
+        let mut child = &mut *child.borrow_mut();
         let is_first_sibling = child.previous_sibling.is_none();
         let is_last_sibling = child.next_sibling.is_none();
 
@@ -335,10 +335,7 @@ impl VirtualEventNode {
             parent.children.as_mut().unwrap().last_child = child.previous_sibling.clone().unwrap();
         }
 
-        match (
-            child.previous_sibling.clone().as_mut(),
-            child.next_sibling.as_mut(),
-        ) {
+        match (child.previous_sibling.as_mut(), child.next_sibling.as_mut()) {
             (Some(previous), Some(next)) => {
                 previous.borrow_mut().next_sibling = Some(next.clone());
                 next.borrow_mut().previous_sibling = Some(previous.clone());


### PR DESCRIPTION
This commit fixing the diffing bug where we were using the wrong node
index when moving siblings under certain conditions.
