### PR TITLE
Use `.parent_element()` instead of `.parent_node().dyn_into()` for DOM elements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "percy"
 version = "0.0.1"
+edition = "2024"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 description = "A modular toolkit for building interactive frontend browser apps with Rust + WebAssembly. Supports server side rendering."
 keywords = ["virtual", "dom", "wasm", "css", "webassembly"]

--- a/crates/percy-css-macro/Cargo.toml
+++ b/crates/percy-css-macro/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "percy-css-macro"
 version = "0.1.1"
+edition = "2024"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 description = "A macro for writing your CSS next to your views"
 keywords = ["css", "style", "stylesheet", "percy", "sheet"]

--- a/crates/percy-dom/src/patch.rs
+++ b/crates/percy-dom/src/patch.rs
@@ -51,7 +51,7 @@ type BreadthFirstNodeIdx = u32;
 // We haven't thought deeply through the implications of breadth first vs. depth first diffing.
 // We can worry about that whenever we optimize our diffing and patching algorithms.
 #[derive(Debug)]
-#[cfg_attr(any(test, feature = "__test-utils"), derive(PartialEq))]
+#[cfg_attr(test, derive(PartialEq))]
 // TODO: Change all of these tuple structs with a `NodeIdx` to instead be `{old_idx: NodeIdx`} so
 //  we can more easily tell which patches use the old node's index vs. the new one's.
 pub enum Patch<'a> {

--- a/crates/percy-dom/src/patch/apply_patches.rs
+++ b/crates/percy-dom/src/patch/apply_patches.rs
@@ -282,8 +282,7 @@ fn apply_element_patch(
             anchor_old_node_idx: _,
             new_nodes,
         } => {
-            let parent = node.parent_node().unwrap();
-            let parent: Element = parent.dyn_into().unwrap();
+            let parent = node.parent_element().unwrap();
 
             let events_parent = events_elem_and_parent.parent.as_ref().unwrap();
 
@@ -303,8 +302,7 @@ fn apply_element_patch(
             anchor_old_node_idx: _,
             to_move,
         } => {
-            let parent = node.parent_node().unwrap();
-            let parent: Element = parent.dyn_into().unwrap();
+            let parent = node.parent_element().unwrap();
 
             let events_parent = events_elem_and_parent.parent.as_ref().unwrap();
             let mut events_parent = events_parent.borrow_mut();

--- a/crates/percy-dom/src/pdom/events.rs
+++ b/crates/percy-dom/src/pdom/events.rs
@@ -65,9 +65,7 @@ fn bubble_event(elem: web_sys::Element, mouse_event: MouseEvent, events: &Virtua
         return;
     }
 
-    if let Some(parent) = elem.parent_node() {
-        if let Ok(parent) = parent.dyn_into() {
-            bubble_event(parent, mouse_event, events);
-        }
+    if let Some(parent) = elem.parent_element() {
+        bubble_event(parent, mouse_event, events);
     }
 }

--- a/crates/percy-preview-app/Cargo.toml
+++ b/crates/percy-preview-app/Cargo.toml
@@ -15,7 +15,7 @@ serde_yaml = "0.8"
 app-world = "0.1"
 console_error_panic_hook = "0.1"
 js-sys = "0.3"
-percy-dom = {path = "../percy-dom", version = "0.9"}
+percy-dom = {path = "../percy-dom", version = "0.10"}
 percy-router = {path = "../percy-router", version = "0.5"}
 percy-preview = {path = "../percy-preview", version = "0.0.3"}
 sunbeam = "0.0.4-alpha"

--- a/crates/percy-router/Cargo.toml
+++ b/crates/percy-router/Cargo.toml
@@ -11,5 +11,5 @@ documentation = "https://chinedufn.github.io/percy/api/percy_router/"
 
 
 [dependencies]
-percy-dom = { path = "../percy-dom", version = "0.9"}
+percy-dom = { path = "../percy-dom", version = "0.10"}
 percy-router-macro = { path = "../percy-router-macro", version = "0.1.5" }


### PR DESCRIPTION
In a few places, Percy accesses a DOM element's parent by calling `.parent_node()`, then calls `.dyn_into()` on that parent node to cast it to a `web_sys::Element`. `.dyn_into()` checks that a type is an `Element` before performing the cast. For some reason, on Firefox, this type check fails, causing `.dyn_into()` to fail and Percy to panic.

In this PR I replaced everywhere Percy calls `.parent_node().dyn_into()` with a call to `.parent_element()`. This method does the same thing as the old code, but doesn't involve a type check, so it prevents Percy from panicking.

---

I'm not really sure what's causing `.dyn_into()` to fail, so I'm just putting some notes on what I found here. It seems to just be a `web-sys` bug. This is the error I saw in my JS console:

```
panicked at /home/bs/dev/contrib/percy/crates/percy-dom/src/patch/apply_patches.rs:286:53:
called `Result::unwrap()` on an `Err` value: Node { obj: EventTarget { obj: Object { obj: JsValue(HTMLDivElement) } } }
```

...which clearly shows the object Percy tried to cast is an `HTMLDivElement`, which is an `Element`, so casting to it should be fine. I also believe this is a `web-sys` bug because I found the same crash if I called `.dyn_into()` to cast the `Element` returned from `.parent_element()`. In my code for this PR I use this line a few times:

```rs
let parent = node.parent_element().unwrap();
```
If you add a `dyn_into` cast under that like so:
```rs
let parent = node.parent_element().unwrap();
let parent: Element = parent.dyn_into().unwrap();
```

The same panic as before happens. Even though it's casting an `Element` to an `Element` ([`.parent_element()` returns an `Option<Element>`](https://docs.rs/web-sys/latest/web_sys/struct.Node.html#method.parent_element)).