### PR TITLE
Add live isomorphic demo Worker config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ node_modules
 tests/jsdom/jsdom_tests*
 examples/isomorphic/client/dist
 examples/isomorphic/client/build
+examples/isomorphic/worker/build
+examples/isomorphic/worker/dist
+examples/isomorphic/worker/.wrangler
+examples/isomorphic/worker/node_modules

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "examples/isomorphic/app",
   "examples/isomorphic/client",
   "examples/isomorphic/server",
+  "examples/isomorphic/worker",
   "examples/unit-testing-components",
   "tests/test-css-rs",
   "tests/test-css-rs-fixture",

--- a/examples/isomorphic/README.md
+++ b/examples/isomorphic/README.md
@@ -1,6 +1,9 @@
 # isomorphic web app example
 
-*TODO: Find a service where we can host a live version of the demo for free or cheaply.*
+Live demo: <https://percy.cinemarob.com>
+
+The demo is hosted on Cloudflare Workers with its static WebAssembly assets
+served by Workers Static Assets.
 
 ## Running Locally
 

--- a/examples/isomorphic/worker/Cargo.toml
+++ b/examples/isomorphic/worker/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "isomorphic-worker"
+version = "0.1.0"
+authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
+publish = false
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+console_error_panic_hook = "0.1"
+isomorphic-app = { path = "../app" }
+url = "2"
+worker = "0.8.5"

--- a/examples/isomorphic/worker/src/lib.rs
+++ b/examples/isomorphic/worker/src/lib.rs
@@ -1,0 +1,55 @@
+use isomorphic_app::App;
+use worker::*;
+
+const DEFAULT_INIT: u32 = 1001;
+const HTML_PLACEHOLDER: &str = "#HTML_INSERTED_HERE_BY_SERVER#";
+const STATE_PLACEHOLDER: &str = "#INITIAL_STATE_JSON#";
+const INDEX_HTML: &str = include_str!("../../server/src/index.html");
+
+#[event(fetch)]
+pub async fn main(req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    console_error_panic_hook::set_once();
+
+    let path = req.path();
+    if path.starts_with("/static/") {
+        return env.assets("ASSETS")?.fetch_request(req).await;
+    }
+
+    match path.as_str() {
+        "/" | "/contributors" => {
+            let init = match initial_count_from_query(req.url()?.query()) {
+                Ok(init) => init,
+                Err(()) => return Response::error("Invalid init query parameter", 400),
+            };
+
+            Response::from_html(render_html(path, init))
+        }
+        _ => Response::error("Not found", 404),
+    }
+}
+
+fn render_html(path: String, init: Option<u32>) -> String {
+    let app = App::new(init.unwrap_or(DEFAULT_INIT), path);
+    let state = app.store.borrow();
+
+    let html = INDEX_HTML.replacen(HTML_PLACEHOLDER, &app.render().to_string(), 1);
+    html.replacen(STATE_PLACEHOLDER, &state.to_json(), 1)
+}
+
+fn initial_count_from_query(query: Option<&str>) -> std::result::Result<Option<u32>, ()> {
+    let Some(query) = query else {
+        return Ok(None);
+    };
+
+    for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+        if key == "init" {
+            if value.is_empty() {
+                return Err(());
+            }
+
+            return value.parse::<u32>().map(Some).map_err(|_| ());
+        }
+    }
+
+    Ok(None)
+}

--- a/examples/isomorphic/worker/wrangler.jsonc
+++ b/examples/isomorphic/worker/wrangler.jsonc
@@ -1,0 +1,10 @@
+{
+  "name": "percy-isomorphic-demo",
+  "main": "./build/worker/shim.mjs",
+  "compatibility_date": "2026-06-15",
+  "workers_dev": true,
+  "assets": {
+    "directory": "./dist",
+    "binding": "ASSETS"
+  }
+}


### PR DESCRIPTION
## Summary

- replace the isomorphic example hosting TODO with a live demo link
- add a small Cloudflare Worker deployment target for the demo
- serve the browser WASM/CSS assets through Workers Static Assets

Live demo: https://percy.cinemarob.com

## Notes

This keeps the existing Actix example untouched. The Worker adapter reuses the existing `isomorphic-app` crate and HTML template, so the deployment target stays isolated from the local server example.

## Validation

- `cargo fmt -p isomorphic-worker -- --check`
- `cargo test -p isomorphic-app`
- `cargo test -p isomorphic-worker`
- `cargo check -p isomorphic-worker --target wasm32-unknown-unknown`
- rebuilt and redeployed the Worker with Dockerized `wasm-pack`, `worker-build`, and Wrangler
- deployed smoke checks for `/`, `/?init=50`, `/contributors`, `/static/app.css`, `/static/isomorphic_client.js`, and `/missing`
- browser smoke test confirmed hydration by clicking from 1001 to 1042

I also attempted the documented `./test.sh` flow from the contributing guide in a Docker container with nightly Rust, `wasm32-unknown-unknown`, Firefox, Geckodriver, and `wasm-pack`. It currently fails during `cargo check --all` in `percy-router-macro-test` because current nightly reports `no_warnings` as dead code under `#![deny(warnings)]`. I confirmed the same focused failure on `origin/master` with `cargo check -p percy-router-macro-test`, so it appears unrelated to this PR.
