### PR TITLE
Make `virtual-node`'s wasm-bindgen optional

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -33,14 +33,6 @@ jobs:
       - name: Browser versions
         run: wasm-pack --version && firefox --version
 
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Run all tests
         run: ./test.sh
 

--- a/crates/html-macro/Cargo.toml
+++ b/crates/html-macro/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["virtual", "dom", "wasm", "assembly", "webassembly"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/chinedufn/percy"
 documentation = "https://chinedufn.github.io/percy/api/html_macro/"
-edition = "2018"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/crates/html-macro/src/tag.rs
+++ b/crates/html-macro/src/tag.rs
@@ -1,9 +1,9 @@
 use proc_macro2::{Span, TokenStream, TokenTree};
-use quote::{quote_spanned, ToTokens};
+use quote::{ToTokens, quote_spanned};
 use syn::parse::{Parse, ParseStream, Result};
 use syn::spanned::Spanned;
 use syn::token::Brace;
-use syn::{braced, Block, Expr, Ident, Token};
+use syn::{Block, Expr, Ident, Token, braced};
 
 /// The different kinds of tokens that we parse.
 ///
@@ -224,12 +224,19 @@ fn parse_attribute_key(input: &mut ParseStream) -> Result<(TokenStream, Span)> {
     if let Some(hyphen) = maybe_hyphen {
         let next_segment = parse_attribute_key_segment(input)?;
 
-        let combined_span = first_key_segment
-            .span()
-            .join(hyphen.span())
-            .unwrap()
-            .join(next_segment.span())
-            .unwrap();
+        // As of July 2026, `Span::join` always returns `None` on stable. So we use `.unwrap_or`.
+        let combined_span = {
+            // `http-`
+            let first_segment_and_hyphen_span = first_key_segment
+                .span()
+                .join(hyphen.span())
+                .unwrap_or(first_key_segment.span());
+
+            // `http-equiv`
+            first_segment_and_hyphen_span
+                .join(next_segment.span())
+                .unwrap_or(first_segment_and_hyphen_span.span())
+        };
 
         attribute_key = (
             quote_spanned! {combined_span=> #first_key_segment - #next_segment },

--- a/crates/percy-dom/Cargo.toml
+++ b/crates/percy-dom/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "percy-dom"
-version = "0.10.0"
+version = "0.10.2"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 description = "A standalone Virtual DOM creation, diffing and patching implementation"
 keywords = ["virtual", "dom", "wasm", "assembly", "webassembly"]
@@ -15,7 +15,7 @@ macro = ["html-macro"]
 
 [dependencies]
 js-sys = "0.3"
-virtual-node = { path = "../virtual-node", version = "0.5.0" }
+virtual-node = { path = "../virtual-node", version = "0.5.1" }
 wasm-bindgen = "0.2.33"
 
 # Optional dependencies

--- a/crates/percy-dom/src/diff.rs
+++ b/crates/percy-dom/src/diff.rs
@@ -794,15 +794,12 @@ mod diff_test_case;
 
 #[cfg(test)]
 mod tests {
+    use super::diff_test_case::*;
     use super::*;
     use crate::event::EventName;
     use crate::{html, EventAttribFn, PatchSpecialAttribute, VText, VirtualNode};
     use std::collections::HashMap;
-    use std::rc::Rc;
     use virtual_node::IterableNodes;
-    use wasm_bindgen::JsValue;
-
-    use super::diff_test_case::*;
 
     /// Verify that we can generate patches that replace a virtual node with another one.
     #[test]
@@ -2921,7 +2918,8 @@ mod tests {
     }
 
     fn mock_event_handler() -> EventHandler {
-        EventHandler::UnsupportedSignature(EventAttribFn(Rc::new(Box::new(JsValue::NULL))))
+        let closure = EventAttribFn::new_noop();
+        EventHandler::UnsupportedSignature(closure)
     }
 
     fn onclick_name() -> EventName {

--- a/crates/percy-dom/src/diff/longest_increasing_subsequence.rs
+++ b/crates/percy-dom/src/diff/longest_increasing_subsequence.rs
@@ -72,7 +72,7 @@ mod tests {
     const D: KeyAndChildIdx = make_val("d", 3);
     const E: KeyAndChildIdx = make_val("e", 4);
 
-    const fn make_val(key: &'static str, val: usize) -> KeyAndChildIdx {
+    const fn make_val(key: &'static str, val: usize) -> KeyAndChildIdx<'static> {
         KeyAndChildIdx {
             key: ElementKey::Explicit(key),
             child_idx: val,

--- a/crates/percy-dom/src/patch/apply_patches.rs
+++ b/crates/percy-dom/src/patch/apply_patches.rs
@@ -464,7 +464,7 @@ fn apply_element_patch(
                         virtual_events.remove_non_delegated_event_wrapper(events_id, event_name);
                     node.remove_event_listener_with_callback(
                         event_name.without_on_prefix(),
-                        wrapper.as_ref().as_ref().unchecked_ref(),
+                        wrapper.as_js_value().unwrap().as_ref().unchecked_ref(),
                     )
                     .unwrap();
                 }

--- a/crates/percy-dom/tests/events.rs
+++ b/crates/percy-dom/tests/events.rs
@@ -342,7 +342,7 @@ fn patch_remove_all_events_with_node_idx() {
     events.insert_event(
         events_id,
         EventName::ONCLICK,
-        EventHandler::UnsupportedSignature(EventAttribFn(Rc::new(JsValue::NULL))),
+        EventHandler::UnsupportedSignature(EventAttribFn::new_noop()),
         None,
     );
 

--- a/crates/percy-router-macro-test/src/lib.rs
+++ b/crates/percy-router-macro-test/src/lib.rs
@@ -73,7 +73,7 @@ fn route_provided_data(state: Provided<State>) -> VirtualNode {
 
 #[test]
 fn provided_data() {
-    let mut router = Router::new(create_routes![route_provided_data]);
+    let router = Router::new(create_routes![route_provided_data]);
 
     router.provide(State { count: 50 });
 
@@ -100,7 +100,7 @@ fn route_provided_two_data(count: Provided<Count>, dollars: Provided<Money>) -> 
 
 #[test]
 fn provided_two_data() {
-    let mut router = Router::new(create_routes![route_provided_two_data]);
+    let router = Router::new(create_routes![route_provided_two_data]);
 
     router.provide(Count { count: 8 });
     router.provide(Money(99));
@@ -126,7 +126,7 @@ fn route_param_and_data(id: u16, state: Provided<SomeState>) -> VirtualNode {
 
 #[test]
 fn provided_param_and_data() {
-    let mut router = Router::new(create_routes![route_param_and_data]);
+    let router = Router::new(create_routes![route_param_and_data]);
 
     router.provide(SomeState { happy: true });
 
@@ -147,7 +147,7 @@ fn route_data_and_param(state: Provided<SomeState>, id: u32) -> VirtualNode {
 
 #[test]
 fn provided_data_and_param() {
-    let mut router = Router::new(create_routes![route_data_and_param]);
+    let router = Router::new(create_routes![route_data_and_param]);
 
     router.provide(SomeState { happy: false });
 
@@ -188,6 +188,11 @@ mod test_no_warnings {
     #[route(path = "/")]
     fn no_warnings() -> VirtualNode {
         unimplemented!()
+    }
+
+    #[expect(unused, reason = "Ensures that `no_warnings` is used.")]
+    fn used() {
+        let _ = no_warnings();
     }
 }
 

--- a/crates/percy-router/Cargo.toml
+++ b/crates/percy-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "percy-router"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 edition = "2018"
 description = "A router for client side web applications with server side rendering support"
@@ -11,5 +11,5 @@ documentation = "https://chinedufn.github.io/percy/api/percy_router/"
 
 
 [dependencies]
-percy-dom = { path = "../percy-dom", version = "0.10"}
+percy-dom = { path = "../percy-dom", version = "0.10.2"}
 percy-router-macro = { path = "../percy-router-macro", version = "0.1.5" }

--- a/crates/virtual-node/Cargo.toml
+++ b/crates/virtual-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "virtual-node"
-version = "0.5.0"
+version = "0.5.1"
 description = "A standalone Virtual DOM"
 authors = ["Chinedu Francis Nwafili <frankie.nwafili@gmail.com>"]
 keywords = ["virtual", "dom", "wasm", "browser", "webassembly"]
@@ -10,14 +10,19 @@ documentation = "https://chinedufn.github.io/percy/api/virtual_node/"
 edition = "2018"
 
 [features]
-MouseEvent = ["web-sys/MouseEvent"]
+# When we introduced the "web" feature in 2026, we made it the default to avoid introducing a breaking change.
+# We have not yet thought whether it is best to have it enabled by default.
+default = ["web"]
+web = ["js-sys", "wasm-bindgen", "web-sys"]
 
 [dependencies]
-js-sys = "0.3"
-wasm-bindgen = "0.2.33"
 html-validation = {path = "../html-validation", version = "0.1.1"}
 
+js-sys = {optional = true, version = "0.3"}
+wasm-bindgen = {optional = true, version = "0.2"}
+
 [dependencies.web-sys]
+optional = true
 version = "0.3"
 features = [
     "Comment",
@@ -35,4 +40,3 @@ features = [
     "MouseEvent",
     "InputEvent",
 ]
-

--- a/crates/virtual-node/README.md
+++ b/crates/virtual-node/README.md
@@ -1,0 +1,9 @@
+# virtual-node
+
+## Overview
+
+`virtual-node` is a virtual DOM node implementation that works in browser and non-browser environments.
+
+## Optional Features
+- **`web`** *(enabled by default)* - Enables support for handling events, such as `onclick`.
+  Enables the `web-sys`, `js-sys` and `wasm-bindgen` dependencies.

--- a/crates/virtual-node/src/create_element.rs
+++ b/crates/virtual-node/src/create_element.rs
@@ -5,7 +5,8 @@ use wasm_bindgen::JsValue;
 use web_sys::{Document, Element};
 
 use crate::event::{VirtualEventElement, VirtualEvents};
-use crate::{AttributeValue, VElement, VirtualEventNode, VirtualNode};
+use crate::{AttributeValue, VElement,  VirtualNode};
+use crate::event::VirtualEventNode;
 
 mod add_events;
 

--- a/crates/virtual-node/src/event.rs
+++ b/crates/virtual-node/src/event.rs
@@ -1,10 +1,3 @@
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::fmt;
-use std::fmt::Formatter;
-use std::ops::{Deref, DerefMut};
-use std::rc::Rc;
-
 pub use self::event_handlers::*;
 pub use self::event_name::EventName;
 pub use self::non_delegated_event_wrapper::insert_non_delegated_event;
@@ -12,18 +5,26 @@ pub(crate) use self::virtual_events::set_events_id;
 pub use self::virtual_events::{
     ElementEventsId, VirtualEventElement, VirtualEventNode, VirtualEvents, ELEMENT_EVENTS_ID_PROP,
 };
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fmt;
+use std::fmt::Formatter;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+use wasm_bindgen::JsValue;
+use web_sys::Event;
 
 mod event_handlers;
 mod event_name;
 mod non_delegated_event_wrapper;
 mod virtual_events;
 
-type EventAttribFnInner = std::rc::Rc<dyn AsRef<wasm_bindgen::JsValue>>;
+/// A type-erased [`js_sys::Closure`]. Stored as a trait object to enable any number of arguments.
+pub(crate) type EventWrapper = std::rc::Rc<dyn EventCallback>;
 
-/// Box<dyn AsRef<JsValue>>> is our js_sys::Closure. Stored this way to allow us to store
-/// any Closure regardless of the types of its arguments.
+/// A handler for an event, such the closure in `onmyevent = || {}`.
 #[derive(Clone)]
-pub struct EventAttribFn(pub EventAttribFnInner);
+pub struct EventAttribFn(EventWrapper);
 
 /// We need a custom implementation of fmt::Debug since JsValue doesn't implement debug.
 #[derive(PartialEq)]
@@ -49,11 +50,7 @@ impl Events {
 
     // Used by the html! macro
     #[doc(hidden)]
-    pub fn __insert_unsupported_signature(
-        &mut self,
-        event_name: EventName,
-        event: EventAttribFnInner,
-    ) {
+    pub fn __insert_unsupported_signature(&mut self, event_name: EventName, event: EventWrapper) {
         self.events
             .insert(event_name, EventHandler::UnsupportedSignature(event.into()));
     }
@@ -75,6 +72,51 @@ impl Events {
         Events {
             events: HashMap::new(),
         }
+    }
+}
+
+/// A callback that runs when an event is triggered.
+///
+/// For instance, this might represent the closure in `onmyevent = |_| {}`.
+pub trait EventCallback {
+    /// Invoke the callback.
+    fn call(&self, event: &web_sys::Event);
+
+    /// Get the underlying [`wasm_bindgen::JsValue`].
+    fn as_js_value(&self) -> Option<&wasm_bindgen::JsValue>;
+}
+
+impl<T: ?Sized> EventCallback for wasm_bindgen::closure::Closure<T> {
+    fn call(&self, event: &web_sys::Event) {
+        use wasm_bindgen::JsCast;
+
+        let context = wasm_bindgen::JsValue::NULL;
+        let callback: &js_sys::Function = self.as_ref().as_ref().unchecked_ref();
+        callback.call1(&context, &event).unwrap();
+    }
+
+    fn as_js_value(&self) -> Option<&wasm_bindgen::JsValue> {
+        Some(self.as_ref())
+    }
+}
+
+impl EventAttribFn {
+    /// Currently used by `crates/percy-dom`'s test suite.
+    #[doc(hidden)]
+    pub fn new_noop() -> Self {
+        struct Noop;
+        impl EventCallback for Noop {
+            fn call(&self, _event: &Event) {}
+
+            fn as_js_value(&self) -> Option<&JsValue> {
+                None
+            }
+        }
+        Self(Rc::new(Noop))
+    }
+
+    pub(crate) fn call(&self, event: &web_sys::Event) {
+        self.0.call(event)
     }
 }
 
@@ -106,17 +148,9 @@ impl fmt::Debug for EventAttribFn {
     }
 }
 
-impl From<EventAttribFnInner> for EventAttribFn {
-    fn from(inner: EventAttribFnInner) -> Self {
+impl From<EventWrapper> for EventAttribFn {
+    fn from(inner: EventWrapper) -> Self {
         EventAttribFn(inner)
-    }
-}
-
-impl Deref for EventAttribFn {
-    type Target = EventAttribFnInner;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/crates/virtual-node/src/event/event_handlers.rs
+++ b/crates/virtual-node/src/event/event_handlers.rs
@@ -4,11 +4,7 @@ use std::fmt::{Debug, Formatter};
 use std::ops::Deref;
 use std::rc::Rc;
 
-/// Event handlers such as the closure in `onclick = |event| {}`.
-///
-/// ## Cloning
-///
-/// Can be cheaply cloned since since inner types are reference counted.
+/// Event handlers such as the closure in `onclick = |mouse_event| {}`.
 #[derive(Clone)]
 pub enum EventHandler {
     /// A callback that does not contain any arguments.

--- a/crates/virtual-node/src/event/non_delegated_event_wrapper.rs
+++ b/crates/virtual-node/src/event/non_delegated_event_wrapper.rs
@@ -3,9 +3,11 @@ use crate::event::{EventHandler, EventName, MouseEvent, VirtualEvents, ELEMENT_E
 use js_sys::Reflect;
 use std::rc::Rc;
 use wasm_bindgen::closure::Closure;
-use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen::JsCast;
 
-/// Insert a non-delegated event
+/// Attaches an event handler directly onto a DOM element.
+///
+/// See [`VirtualEvents`] and [`EventName::is_delegated`] for documentation regarding event delegation.
 pub fn insert_non_delegated_event(
     element: &web_sys::Element,
     onevent: &EventName,
@@ -41,12 +43,7 @@ pub fn insert_non_delegated_event(
             EventHandler::MouseEvent(mouse) => {
                 (mouse.borrow_mut())(MouseEvent::new(event.dyn_into().unwrap()));
             }
-            EventHandler::UnsupportedSignature(cb) => {
-                let cb: &js_sys::Function = cb.as_ref().as_ref().unchecked_ref();
-
-                let context = JsValue::NULL;
-                cb.call1(&context, &event).unwrap();
-            }
+            EventHandler::UnsupportedSignature(cb) => cb.call(&event),
         };
     };
 

--- a/crates/virtual-node/src/event/virtual_events.rs
+++ b/crates/virtual-node/src/event/virtual_events.rs
@@ -1,10 +1,8 @@
 use crate::event::event_name::EventName;
-use crate::event::EventHandler;
-use js_sys::Reflect;
+use crate::event::{EventHandler, EventWrapper};
 use std::cell::{Ref, RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::Rc;
-use wasm_bindgen::JsValue;
 
 // Every real DOM element that we create gets a property set on it that can be used to look up
 // its events in [`crate::VirtualEvents`].
@@ -26,12 +24,6 @@ impl ElementEventsId {
         self.0
     }
 }
-
-// Really only needs to be boxed.. but using an Rc let's us implement the
-//  removes_old_non_delegated_event_listeners test.
-// A future optimization could be using a feature flag to determine whether to Rc or Box this.
-// i.e. #[cfg(feature = "__test-utils")]
-pub(crate) type EventWrapper = Rc<dyn AsRef<JsValue>>;
 
 /// When we create a DOM node, we store all of it's closures and all of it's children's closures
 /// in VirtualEvents.
@@ -430,7 +422,12 @@ impl VirtualEventElement {
     }
 }
 
-pub(crate) fn set_events_id(node: &JsValue, events: &VirtualEvents, events_id: ElementEventsId) {
+pub(crate) fn set_events_id(
+    node: &wasm_bindgen::JsValue,
+    events: &VirtualEvents,
+    events_id: ElementEventsId,
+) {
+    use js_sys::Reflect;
     Reflect::set(
         &node.into(),
         &ELEMENT_EVENTS_ID_PROP.into(),

--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -11,18 +11,19 @@
 
 use std::fmt;
 
-use crate::event::{VirtualEventNode, VirtualEvents};
-use web_sys::{self, Node};
-
+#[cfg(feature = "web")]
 pub use self::create_element::VIRTUAL_NODE_MARKER_PROPERTY;
+#[cfg(feature = "web")]
 pub use self::event::EventAttribFn;
 pub use self::iterable_nodes::*;
 pub use self::velement::*;
 pub use self::vtext::*;
 
+#[cfg(feature = "web")]
 pub mod event;
 pub mod test_utils;
 
+#[cfg(feature = "web")]
 mod create_element;
 
 mod iterable_nodes;
@@ -136,7 +137,11 @@ impl VirtualNode {
     }
 
     /// Create and return a [`web_sys::Node`] along with its events.
-    pub fn create_dom_node(&self, events: &mut VirtualEvents) -> (Node, VirtualEventNode) {
+    #[cfg(feature = "web")]
+    pub fn create_dom_node(
+        &self,
+        events: &mut self::event::VirtualEvents,
+    ) -> (web_sys::Node, crate::event::VirtualEventNode) {
         match self {
             VirtualNode::Text(text_node) => (
                 text_node.create_text_node().into(),

--- a/crates/virtual-node/src/velement.rs
+++ b/crates/virtual-node/src/velement.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use crate::event::Events;
 use crate::VirtualNode;
 
 pub use self::attribute_value::*;
@@ -20,7 +19,8 @@ pub struct VElement {
     ///
     /// Events natively handled in HTML such as onclick, onchange, oninput and others
     /// can be found in [`VElement.known_events`]
-    pub events: Events,
+    #[cfg(feature = "web")]
+    pub events: crate::event::Events,
     /// The children of this `VirtualNode`. So a <div> <em></em> </div> structure would
     /// have a parent div and one child, em.
     pub children: Vec<VirtualNode>,
@@ -36,7 +36,8 @@ impl VElement {
         VElement {
             tag: tag.into(),
             attrs: HashMap::new(),
-            events: Events::new(),
+            #[cfg(feature = "web")]
+            events: crate::event::Events::new(),
             children: vec![],
             special_attributes: SpecialAttributes::default(),
         }

--- a/crates/virtual-node/src/velement/attribute_value.rs
+++ b/crates/virtual-node/src/velement/attribute_value.rs
@@ -1,5 +1,4 @@
 use std::fmt::{Display, Formatter};
-use wasm_bindgen::JsValue;
 
 /// The value associated with an element's attribute.
 ///
@@ -55,8 +54,9 @@ macro_rules! to_string_impls {
 }
 to_string_impls!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128, f32, f64);
 
-impl Into<JsValue> for AttributeValue {
-    fn into(self) -> JsValue {
+#[cfg(feature = "web")]
+impl Into<wasm_bindgen::JsValue> for AttributeValue {
+    fn into(self) -> wasm_bindgen::JsValue {
         match self {
             AttributeValue::String(s) => s.into(),
             AttributeValue::Bool(b) => b.into(),

--- a/crates/virtual-node/src/velement/special_attributes.rs
+++ b/crates/virtual-node/src/velement/special_attributes.rs
@@ -1,6 +1,4 @@
 use std::borrow::Cow;
-use std::cell::RefCell;
-use std::ops::DerefMut;
 
 /// A specially supported attributes.
 #[derive(Default, PartialEq)]
@@ -8,10 +6,12 @@ pub struct SpecialAttributes {
     /// A a function that gets called when the virtual node is first turned into a real node.
     ///
     /// See [`SpecialAttributes.set_on_create_element`] for more documentation.
+    #[cfg(feature = "web")]
     on_create_element: Option<KeyAndElementFn>,
     /// A a function that gets called when the virtual node is first turned into a real node.
     ///
     /// See [`SpecialAttributes.set_on_remove_element`] for more documentation.
+    #[cfg(feature = "web")]
     on_remove_element: Option<KeyAndElementFn>,
     /// Allows setting the innerHTML of an element.
     ///
@@ -23,6 +23,7 @@ pub struct SpecialAttributes {
 
 impl SpecialAttributes {
     /// The key for the on create element function
+    #[cfg(feature = "web")]
     pub fn on_create_element_key(&self) -> Option<&Cow<'static, str>> {
         self.on_create_element.as_ref().map(|k| &k.key)
     }
@@ -59,6 +60,7 @@ impl SpecialAttributes {
     ///     .special_attributes
     ///     .set_on_create_element(key, on_create_elem);
     /// ```
+    #[cfg(feature = "web")]
     pub fn set_on_create_element<Key, Func>(&mut self, key: Key, func: Func)
     where
         Key: Into<Cow<'static, str>>,
@@ -66,7 +68,7 @@ impl SpecialAttributes {
     {
         self.on_create_element = Some(KeyAndElementFn {
             key: key.into(),
-            func: RefCell::new(ElementFunc::OneArg(Box::new(func))),
+            func: std::cell::RefCell::new(ElementFunc::OneArg(Box::new(func))),
         });
     }
 
@@ -77,13 +79,21 @@ impl SpecialAttributes {
         Key: Into<Cow<'static, str>>,
         Func: FnMut() + 'static,
     {
-        self.on_create_element = Some(KeyAndElementFn {
-            key: key.into(),
-            func: RefCell::new(ElementFunc::NoArgs(Box::new(func))),
-        });
+        #[cfg(feature = "web")]
+        {
+            self.on_create_element = Some(KeyAndElementFn {
+                key: key.into(),
+                func: std::cell::RefCell::new(ElementFunc::NoArgs(Box::new(func))),
+            });
+        }
+        #[cfg(not(feature = "web"))]
+        {
+            let _ = (key, func);
+        }
     }
 
     /// If an `on_create_element` function was set, call it.
+    #[cfg(feature = "web")]
     pub fn maybe_call_on_create_element(&self, element: &web_sys::Element) {
         if let Some(on_create_elem) = &self.on_create_element {
             on_create_elem.call(element.clone());
@@ -95,6 +105,7 @@ impl SpecialAttributes {
 
 impl SpecialAttributes {
     /// The key for the on remove element function
+    #[cfg(feature = "web")]
     pub fn on_remove_element_key(&self) -> Option<&Cow<'static, str>> {
         self.on_remove_element.as_ref().map(|k| &k.key)
     }
@@ -131,6 +142,7 @@ impl SpecialAttributes {
     ///     .special_attributes
     ///     .set_on_remove_element(key, on_remove_elem);
     /// ```
+    #[cfg(feature = "web")]
     pub fn set_on_remove_element<Key, Func>(&mut self, key: Key, func: Func)
     where
         Key: Into<Cow<'static, str>>,
@@ -138,7 +150,7 @@ impl SpecialAttributes {
     {
         self.on_remove_element = Some(KeyAndElementFn {
             key: key.into(),
-            func: RefCell::new(ElementFunc::OneArg(Box::new(func))),
+            func: std::cell::RefCell::new(ElementFunc::OneArg(Box::new(func))),
         });
     }
 
@@ -149,13 +161,21 @@ impl SpecialAttributes {
         Key: Into<Cow<'static, str>>,
         Func: FnMut() + 'static,
     {
-        self.on_remove_element = Some(KeyAndElementFn {
-            key: key.into(),
-            func: RefCell::new(ElementFunc::NoArgs(Box::new(func))),
-        });
+        #[cfg(feature = "web")]
+        {
+            self.on_remove_element = Some(KeyAndElementFn {
+                key: key.into(),
+                func: std::cell::RefCell::new(ElementFunc::NoArgs(Box::new(func))),
+            });
+        }
+        #[cfg(not(feature = "web"))]
+        {
+            let _ = (key, func);
+        }
     }
 
     /// If an `on_remove_element` function was set, call it.
+    #[cfg(feature = "web")]
     pub fn maybe_call_on_remove_element(&self, element: &web_sys::Element) {
         if let Some(on_remove_elem) = &self.on_remove_element {
             on_remove_elem.call(element.clone());
@@ -165,18 +185,23 @@ impl SpecialAttributes {
     }
 }
 
+#[cfg(feature = "web")]
 struct KeyAndElementFn {
     key: Cow<'static, str>,
-    func: RefCell<ElementFunc>,
+    func: std::cell::RefCell<ElementFunc>,
 }
 
+#[cfg(feature = "web")]
 enum ElementFunc {
     NoArgs(Box<dyn FnMut()>),
     OneArg(Box<dyn FnMut(web_sys::Element)>),
 }
 
+#[cfg(feature = "web")]
 impl KeyAndElementFn {
     fn call(&self, element: web_sys::Element) {
+        use std::ops::DerefMut;
+
         match self.func.borrow_mut().deref_mut() {
             ElementFunc::NoArgs(func) => (func)(),
             ElementFunc::OneArg(func) => (func)(element),
@@ -184,6 +209,7 @@ impl KeyAndElementFn {
     }
 }
 
+#[cfg(feature = "web")]
 impl PartialEq for KeyAndElementFn {
     fn eq(&self, rhs: &Self) -> bool {
         self.key == rhs.key

--- a/crates/virtual-node/src/vtext.rs
+++ b/crates/virtual-node/src/vtext.rs
@@ -1,7 +1,5 @@
 use std::fmt;
 
-use crate::create_element::set_virtual_node_marker;
-use web_sys::Text;
 
 /// Represents a text node
 #[derive(PartialEq)]
@@ -20,7 +18,10 @@ impl VText {
 
     /// Return a `Text` element from a `VirtualNode`, typically right before adding it
     /// into the DOM.
-    pub(crate) fn create_text_node(&self) -> Text {
+    #[cfg(feature = "web")]
+    pub(crate) fn create_text_node(&self) -> web_sys::Text {
+        use crate::create_element::set_virtual_node_marker;
+
         let document = web_sys::window().unwrap().document().unwrap();
         let text = document.create_text_node(&self.text);
 

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
+set -e
+
 cd $(git rev-parse --show-toplevel)
 
-cargo check --all && # Make sure examples compile
-cargo test --all &&
+cargo check --all
+cargo test --all
+
+# Ensure that `crates/virtual-dom` can compile without web-sys/js-sys/wasm-bindgen.
+cargo check -p virtual-node --no-default-features
+
 wasm-pack test --firefox --headless crates/percy-dom


### PR DESCRIPTION
This commit makes `crates/virtual-node`'s `js-sys`, `wasm-bindgen` and
`web-sys` dependencies optional.

This removes unnecessary dependencies when using `virtual-node` outside
of web browsers, such as for server-side rendering.
