### PR TITLE
Set element key independently

### DIFF
--- a/crates/html-macro/src/parser/open_tag/event.rs
+++ b/crates/html-macro/src/parser/open_tag/event.rs
@@ -59,8 +59,14 @@ Documentation:
         quote! {
             let event_callback = #closure;
 
-            #var_name_node.as_elem_mut().unwrap()
-              .special_attributes.#setter(#key_attr_value.to_string(), event_callback);
+            {
+                let elem = #var_name_node.as_elem_mut().unwrap();
+                elem.special_attributes.set_key(#key_attr_value.to_string());
+                elem
+                  .special_attributes.#setter(event_callback)
+                  .unwrap();
+            }
+
 
             #maybe_missing_key_error
         }
@@ -100,8 +106,11 @@ Documentation:
         quote! {
             let event_callback = #closure;
 
-            #var_name_node.as_elem_mut().unwrap()
-              .special_attributes.#setter(#key_attr_value.to_string(), event_callback);
+            {
+                let elem = #var_name_node.as_elem_mut().unwrap();
+                elem.special_attributes.set_key(#key_attr_value.to_string());
+                elem.special_attributes.#setter(event_callback).unwrap();
+            };
 
             #maybe_missing_key_error
         }

--- a/crates/percy-dom/src/diff.rs
+++ b/crates/percy-dom/src/diff.rs
@@ -2914,20 +2914,24 @@ mod tests {
         node: &mut VirtualNode<web_sys::Window>,
         on_create_elem_id: &'static str,
     ) {
-        node.as_elem_mut()
-            .unwrap()
-            .special_attributes
-            .set_on_create_element(on_create_elem_id, |_: web_sys::Element| {});
+        let elem = node.as_elem_mut().unwrap();
+        let special = &mut elem.special_attributes;
+        special.set_key(on_create_elem_id);
+        special
+            .set_on_create_element(|_: web_sys::Element| {})
+            .unwrap();
     }
 
     fn set_on_remove_elem_with_unique_id(
         node: &mut VirtualNode<web_sys::Window>,
         on_remove_elem_id: &'static str,
     ) {
-        node.as_elem_mut()
-            .unwrap()
-            .special_attributes
-            .set_on_remove_element(on_remove_elem_id, |_: web_sys::Element| {});
+        let elem = node.as_elem_mut().unwrap();
+        let special = &mut elem.special_attributes;
+        special.set_key(on_remove_elem_id);
+        special
+            .set_on_remove_element(|_: web_sys::Element| {})
+            .unwrap();
     }
 
     fn set_dangerous_inner_html(node: &mut VirtualNode<web_sys::Window>, html: &str) {

--- a/crates/percy-dom/tests/diff_patch_test_case/mod.rs
+++ b/crates/percy-dom/tests/diff_patch_test_case/mod.rs
@@ -2,7 +2,6 @@
 
 use console_error_panic_hook;
 use percy_dom::event::VirtualEvents;
-use percy_dom::prelude::*;
 use virtual_node::VirtualNodeWebSys;
 use wasm_bindgen::JsCast;
 use web_sys::{Element, Node};

--- a/crates/percy-dom/tests/keyed_lists.rs
+++ b/crates/percy-dom/tests/keyed_lists.rs
@@ -22,7 +22,7 @@ use web_sys::Node;
 
 use crate::testing_utilities::create_node_and_events_and_append_to_document;
 use percy_dom::prelude::*;
-use virtual_node::event::{VirtualEvents, VirtualEventsWebSys, ELEMENT_EVENTS_ID_PROP};
+use virtual_node::event::{ELEMENT_EVENTS_ID_PROP, VirtualEventsWebSys};
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/crates/percy-dom/tests/on_create_element.rs
+++ b/crates/percy-dom/tests/on_create_element.rs
@@ -30,12 +30,13 @@ fn on_create_elem_new_node() {
     </div>
     };
 
-    div.as_elem_mut()
-        .unwrap()
-        .special_attributes
-        .set_on_create_element("foo", move |elem: web_sys::Element| {
+    let elem = div.as_elem_mut().unwrap();
+    elem.special_attributes.set_key("foo");
+    elem.special_attributes
+        .set_on_create_element(move |elem: web_sys::Element| {
             elem.set_inner_html("Hello world");
-        });
+        })
+        .unwrap();
 
     let div: Element = div
         .create_dom_node(&mut VirtualEvents::new())
@@ -55,13 +56,15 @@ fn on_create_elem_triggered_via_patch() {
 
     let end_id = random_id();
     let mut end: VirtualNodeWebSys = html! { <div id=end_id> </div>};
-    end.as_elem_mut()
-        .unwrap()
+    let end_elem = end.as_elem_mut().unwrap();
+    end_elem.special_attributes.set_key("foo");
+    end_elem
         .special_attributes
-        .set_on_create_element("foo", move |elem: web_sys::Element| {
+        .set_on_create_element(move |elem: web_sys::Element| {
             assert_eq!(elem.id(), end_id);
             elem.set_inner_html("Hello world");
-        });
+        })
+        .unwrap();
 
     let mut events = VirtualEvents::new();
     let (div, enode) = start.create_dom_node(&mut events);
@@ -82,19 +85,22 @@ fn on_create_elem_triggered_via_patch() {
 #[wasm_bindgen_test]
 fn on_create_elem_not_triggered_via_patch_if_same_id() {
     let mut start = html! {<div id="original"></div>};
-    start
-        .as_elem_mut()
-        .unwrap()
+    let start_elem = start.as_elem_mut().unwrap();
+    start_elem.special_attributes.set_key("same-key");
+    start_elem
         .special_attributes
-        .set_on_create_element("same-key", |_elem: web_sys::Element| {});
+        .set_on_create_element(|_elem: web_sys::Element| {})
+        .unwrap();
 
     let mut end: VirtualNodeWebSys = html! {<div id="new"></div>};
-    end.as_elem_mut()
-        .unwrap()
+    let end_elem = end.as_elem_mut().unwrap();
+    end_elem.special_attributes.set_key("same-key");
+    end_elem
         .special_attributes
-        .set_on_create_element("same-key", move |_elem: web_sys::Element| {
+        .set_on_create_element(move |_elem: web_sys::Element| {
             panic!("On create element function should not have gotten called.");
-        });
+        })
+        .unwrap();
 
     let mut events = VirtualEvents::new();
     let (div, enode) = start.create_dom_node(&mut events);

--- a/crates/percy-dom/tests/on_remove_element.rs
+++ b/crates/percy-dom/tests/on_remove_element.rs
@@ -29,13 +29,15 @@ fn remove_node() {
     let called_clone = called.clone();
 
     let mut old = html! { <div id=old_elem_id> </div> };
-    old.as_elem_mut()
-        .unwrap()
+    let old_elem = old.as_elem_mut().unwrap();
+    old_elem.special_attributes.set_key("foo");
+    old_elem
         .special_attributes
-        .set_on_remove_element("foo", move |elem: web_sys::Element| {
+        .set_on_remove_element(move |elem: web_sys::Element| {
             assert_eq!(elem.id(), old_elem_id);
             called_clone.set(true);
-        });
+        })
+        .unwrap();
 
     let new = VirtualNode::new_element("span");
 
@@ -60,14 +62,15 @@ fn on_remove_elem_called_on_children() {
     let mut child = html! {
          <em id = child_id></em>
     };
-    child
-        .as_elem_mut()
-        .unwrap()
+    let child_elem = child.as_elem_mut().unwrap();
+    child_elem.special_attributes.set_key("foo");
+    child_elem
         .special_attributes
-        .set_on_remove_element("foo", move |elem: web_sys::Element| {
+        .set_on_remove_element(move |elem: web_sys::Element| {
             assert_eq!(elem.id(), child_id);
             called_clone.set(true);
-        });
+        })
+        .unwrap();
 
     let old = html! {
         <div>{ child }</div>

--- a/crates/percy-dom/tests/testing_utilities.rs
+++ b/crates/percy-dom/tests/testing_utilities.rs
@@ -1,7 +1,7 @@
 //! Various helper functions and types for writing tests.
 
+use virtual_node::VirtualNodeWebSys;
 use virtual_node::event::{VirtualEvents, VirtualEventsWebSys};
-use virtual_node::{VirtualNode, VirtualNodeWebSys};
 use wasm_bindgen::JsCast;
 use web_sys::Node;
 

--- a/crates/virtual-node/src/event.rs
+++ b/crates/virtual-node/src/event.rs
@@ -118,6 +118,10 @@ impl<Dom: RealDom> Events<Dom> {
 ///
 /// [`VirtualNode`]: crate::VirtualNode
 pub trait RealDom {
+    /// The element type. In the web this is [`web_sys::Element`].
+    // `Clone` bound is currently used by ``
+    type Element: Clone;
+
     /// The event type. In the web this is [`web_sys::Event`].
     type Event;
     /// The event type for mouse events. In the web this is [`web_sys::MouseEvent`].
@@ -129,12 +133,16 @@ pub trait RealDom {
 /// An [`RealDom`] implementation that uses [`web_sys`]'s event types.
 #[cfg(feature = "web")]
 impl RealDom for web_sys::Window {
+    type Element = web_sys::Element;
+
     type Event = web_sys::Event;
     type MouseEvent = crate::event::MouseEventWebSys;
     type EventCallback = Rc<dyn AsRef<wasm_bindgen::JsValue>>;
 }
 
 impl RealDom for () {
+    type Element = ();
+
     type Event = ();
     type MouseEvent = ();
     type EventCallback = ();

--- a/crates/virtual-node/src/lib.rs
+++ b/crates/virtual-node/src/lib.rs
@@ -147,6 +147,7 @@ impl<Dom: RealDom> VirtualNode<Dom> {
         // error: reached the recursion limit while instantiating `VirtualNode::<NewDomType>::map_real_dom::<Window, &&&&&&&&&&&&&&&&&&&...>
         // ```
         convert_event: &dyn Fn(EventHandler<Dom>) -> EventHandler<New>,
+        convert_lifecycle: &dyn Fn(Box<dyn FnMut(Dom::Element)>) -> Box<dyn FnMut(New::Element)>,
     ) -> VirtualNode<New> {
         match self {
             VirtualNode::Text(text) => VirtualNode::Text(text),
@@ -154,7 +155,7 @@ impl<Dom: RealDom> VirtualNode<Dom> {
                 let children: Vec<VirtualNode<New>> = elem
                     .children
                     .into_iter()
-                    .map(|old| old.map_real_dom::<New>(convert_event))
+                    .map(|old| old.map_real_dom::<New>(convert_event, convert_lifecycle))
                     .collect();
 
                 VirtualNode::Element(VirtualElement {
@@ -162,7 +163,7 @@ impl<Dom: RealDom> VirtualNode<Dom> {
                     attrs: elem.attrs,
                     events: elem.events.convert_all(convert_event),
                     children,
-                    special_attributes: elem.special_attributes,
+                    special_attributes: elem.special_attributes.map_dom(convert_lifecycle),
                 })
             }
         }

--- a/crates/virtual-node/src/velement.rs
+++ b/crates/virtual-node/src/velement.rs
@@ -9,7 +9,7 @@ pub use self::special_attributes::*;
 mod attribute_value;
 mod special_attributes;
 
-pub struct VirtualElement<Handle: RealDom> {
+pub struct VirtualElement<Dom: RealDom> {
     /// The HTML tag, such as "div"
     pub tag: String,
     /// HTML attributes such as id, class, style, etc
@@ -18,15 +18,15 @@ pub struct VirtualElement<Handle: RealDom> {
     ///
     /// Events natively handled in HTML such as onclick, onchange, oninput and others
     /// can be found in [`VElement.known_events`]
-    pub events: Events<Handle>,
+    pub events: Events<Dom>,
     /// The children of this `VirtualNode`. So a <div> <em></em> </div> structure would
     /// have a parent div and one child, em.
-    pub children: Vec<VirtualNode<Handle>>,
+    pub children: Vec<VirtualNode<Dom>>,
     /// See [`SpecialAttributes`]
-    pub special_attributes: SpecialAttributes,
+    pub special_attributes: SpecialAttributes<Dom>,
 }
 
-impl<Handle: RealDom> PartialEq for VirtualElement<Handle> {
+impl<Dom: RealDom> PartialEq for VirtualElement<Dom> {
     fn eq(&self, other: &Self) -> bool {
         let VirtualElement {
             tag: lhs_tag,
@@ -51,8 +51,8 @@ impl<Handle: RealDom> PartialEq for VirtualElement<Handle> {
     }
 }
 
-impl<Handle: RealDom> VirtualElement<Handle> {
-    pub fn new(tag: impl Into<String>) -> VirtualElement<Handle> {
+impl<Dom: RealDom> VirtualElement<Dom> {
+    pub fn new(tag: impl Into<String>) -> VirtualElement<Dom> {
         VirtualElement {
             tag: tag.into(),
             attrs: HashMap::new(),
@@ -63,7 +63,7 @@ impl<Handle: RealDom> VirtualElement<Handle> {
     }
 }
 
-impl<Handle: RealDom> fmt::Debug for VirtualElement<Handle> {
+impl<Dom: RealDom> fmt::Debug for VirtualElement<Dom> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
@@ -73,7 +73,7 @@ impl<Handle: RealDom> fmt::Debug for VirtualElement<Handle> {
     }
 }
 
-impl<Handle: RealDom> fmt::Display for VirtualElement<Handle> {
+impl<Dom: RealDom> fmt::Display for VirtualElement<Dom> {
     // Turn a VElement and all of it's children (recursively) into an HTML string
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "<{}", self.tag).unwrap();

--- a/crates/virtual-node/src/velement/special_attributes.rs
+++ b/crates/virtual-node/src/velement/special_attributes.rs
@@ -1,18 +1,18 @@
+use crate::event::RealDom;
 use std::borrow::Cow;
+use std::cell::RefCell;
 
 /// A specially supported attributes.
-#[derive(Default, PartialEq)]
-pub struct SpecialAttributes {
+pub struct SpecialAttributes<Dom: RealDom> {
+    key: Option<Cow<'static, str>>,
     /// A function that gets called when the virtual node is first turned into a real node.
     ///
     /// See [`SpecialAttributes.set_on_create_element`] for more documentation.
-    #[cfg(feature = "web")]
-    on_create_element: Option<KeyAndElementFn>,
+    on_create_element: Option<CreateOrRemoveElementFn<Dom>>,
     /// A function that gets called when the virtual node is first turned into a real node.
     ///
     /// See [`SpecialAttributes.set_on_remove_element`] for more documentation.
-    #[cfg(feature = "web")]
-    on_remove_element: Option<KeyAndElementFn>,
+    on_remove_element: Option<CreateOrRemoveElementFn<Dom>>,
     /// Allows setting the innerHTML of an element.
     ///
     /// # Danger
@@ -21,18 +21,51 @@ pub struct SpecialAttributes {
     pub dangerous_inner_html: Option<String>,
 }
 
-impl SpecialAttributes {
-    /// The key for the on create element function
-    #[cfg(feature = "web")]
+/// An error when attempting to perform an action that requires the [`SpecialAttributes::key`] to be
+/// set.
+#[derive(Debug)]
+pub struct KeyNotSetError;
+
+impl<Dom: RealDom> SpecialAttributes<Dom> {
+    /// Keys can distinguish two elements that have the same tag.
+    ///
+    /// For example, if one `div` has key `old-key`, and another `div` has key `new-key`, the two
+    /// elements are considered different.
+    pub fn key(&self) -> Option<&str> {
+        self.key.as_ref().map(|key| key.as_ref())
+    }
+
+    /// Set the element's `key`.
+    pub fn set_key<Key>(&mut self, key: Key)
+    where
+        Key: Into<Cow<'static, str>>,
+    {
+        self.key = Some(key.into());
+    }
+
+    /// Returns the element's key if an `on_create_element` function is set.
     pub fn on_create_element_key(&self) -> Option<&Cow<'static, str>> {
-        self.on_create_element.as_ref().map(|k| &k.key)
+        if self.on_create_element.is_some() {
+            return self.key.as_ref();
+        }
+        None
+    }
+
+    /// Combines [`SpecialAttributes::set_key`] and [`SpecialAttributes::set_on_create_element`].
+    pub fn set_key_and_on_create_element<Key, Func>(&mut self, key: Key, func: Func)
+    where
+        Key: Into<Cow<'static, str>>,
+        Func: FnMut(Dom::Element) + 'static,
+    {
+        self.set_key(key);
+        self.set_on_create_element(func).unwrap()
     }
 
     /// Set the [`SpecialAttributes.on_create_element`] function.
     ///
     /// # Key
     ///
-    /// The key is used when one virtual-node is being patched over another.
+    /// The [`SpecialAttributes::key`] is used when one virtual-node is being patched over another.
     ///
     /// If the new node's key is different from the old node's key, the on create element function
     /// gets called.
@@ -54,60 +87,55 @@ impl SpecialAttributes {
     ///     assert_eq!(elem.id(), "");
     /// };
     ///
-    /// node
-    ///     .as_elem_mut()
-    ///     .unwrap()
-    ///     .special_attributes
-    ///     .set_on_create_element(key, on_create_elem);
+    /// let elem = node.as_elem_mut().unwrap();
+    /// elem.special_attributes.set_key(key);
+    /// elem.special_attributes.set_on_create_element(on_create_elem).unwrap();
     /// ```
-    #[cfg(feature = "web")]
-    pub fn set_on_create_element<Key, Func>(&mut self, key: Key, func: Func)
+    pub fn set_on_create_element<Func>(&mut self, func: Func) -> Result<(), KeyNotSetError>
     where
-        Key: Into<Cow<'static, str>>,
-        Func: FnMut(web_sys::Element) + 'static,
+        Func: FnMut(Dom::Element) + 'static,
     {
-        self.on_create_element = Some(KeyAndElementFn {
-            key: key.into(),
-            func: std::cell::RefCell::new(ElementFunc::OneArg(Box::new(func))),
+        if self.key.is_none() {
+            return Err(KeyNotSetError);
+        }
+
+        self.on_create_element = Some(CreateOrRemoveElementFn {
+            func: RefCell::new(ElementFunc::OneArg(Box::new(func))),
         });
+        Ok(())
     }
 
     // Used by the html-macro
     #[doc(hidden)]
-    pub fn set_on_create_element_no_args<Key, Func>(&mut self, key: Key, func: Func)
+    pub fn set_on_create_element_no_args<Func>(&mut self, func: Func) -> Result<(), KeyNotSetError>
     where
-        Key: Into<Cow<'static, str>>,
         Func: FnMut() + 'static,
     {
-        #[cfg(feature = "web")]
-        {
-            self.on_create_element = Some(KeyAndElementFn {
-                key: key.into(),
-                func: std::cell::RefCell::new(ElementFunc::NoArgs(Box::new(func))),
-            });
+        if self.key.is_none() {
+            return Err(KeyNotSetError);
         }
-        #[cfg(not(feature = "web"))]
-        {
-            let _ = (key, func);
-        }
+
+        self.on_create_element = Some(CreateOrRemoveElementFn {
+            func: RefCell::new(ElementFunc::NoArgs(Box::new(func))),
+        });
+        Ok(())
     }
 
     /// If an `on_create_element` function was set, call it.
-    #[cfg(feature = "web")]
-    pub fn maybe_call_on_create_element(&self, element: &web_sys::Element) {
+    pub fn maybe_call_on_create_element(&self, element: &Dom::Element) {
         if let Some(on_create_elem) = &self.on_create_element {
             on_create_elem.call(element.clone());
         }
-
-        let _ = element;
     }
 }
 
-impl SpecialAttributes {
-    /// The key for the on remove element function
-    #[cfg(feature = "web")]
+impl<Dom: RealDom> SpecialAttributes<Dom> {
+    /// Returns the element's key if an `on_remove_element` function is set.
     pub fn on_remove_element_key(&self) -> Option<&Cow<'static, str>> {
-        self.on_remove_element.as_ref().map(|k| &k.key)
+        if self.on_remove_element.is_some() {
+            return self.key.as_ref();
+        }
+        None
     }
 
     /// Set the [`SpecialAttributes.on_remove_element`] function.
@@ -136,82 +164,214 @@ impl SpecialAttributes {
     ///     assert_eq!(elem.id(), "");
     /// };
     ///
-    /// node
-    ///     .as_elem_mut()
-    ///     .unwrap()
-    ///     .special_attributes
-    ///     .set_on_remove_element(key, on_remove_elem);
+    /// let elem = node.as_elem_mut().unwrap();
+    /// elem.special_attributes.set_key(key);
+    /// elem.special_attributes.set_on_remove_element(on_remove_elem);
     /// ```
-    #[cfg(feature = "web")]
-    pub fn set_on_remove_element<Key, Func>(&mut self, key: Key, func: Func)
+    pub fn set_on_remove_element<Func>(&mut self, func: Func) -> Result<(), KeyNotSetError>
     where
-        Key: Into<Cow<'static, str>>,
-        Func: FnMut(web_sys::Element) + 'static,
+        Func: FnMut(Dom::Element) + 'static,
     {
-        self.on_remove_element = Some(KeyAndElementFn {
-            key: key.into(),
+        if self.key.is_none() {
+            return Err(KeyNotSetError);
+        }
+
+        self.on_remove_element = Some(CreateOrRemoveElementFn {
             func: std::cell::RefCell::new(ElementFunc::OneArg(Box::new(func))),
         });
+        Ok(())
     }
 
     // Used by the html-macro
     #[doc(hidden)]
-    pub fn set_on_remove_element_no_args<Key, Func>(&mut self, key: Key, func: Func)
+    pub fn set_on_remove_element_no_args<Func>(&mut self, func: Func) -> Result<(), KeyNotSetError>
     where
-        Key: Into<Cow<'static, str>>,
         Func: FnMut() + 'static,
     {
-        #[cfg(feature = "web")]
-        {
-            self.on_remove_element = Some(KeyAndElementFn {
-                key: key.into(),
-                func: std::cell::RefCell::new(ElementFunc::NoArgs(Box::new(func))),
-            });
+        if self.key.is_none() {
+            return Err(KeyNotSetError);
         }
-        #[cfg(not(feature = "web"))]
-        {
-            let _ = (key, func);
-        }
+
+        self.on_remove_element = Some(CreateOrRemoveElementFn {
+            func: RefCell::new(ElementFunc::NoArgs(Box::new(func))),
+        });
+        Ok(())
     }
 
     /// If an `on_remove_element` function was set, call it.
-    #[cfg(feature = "web")]
-    pub fn maybe_call_on_remove_element(&self, element: &web_sys::Element) {
+    pub fn maybe_call_on_remove_element(&self, element: &Dom::Element) {
         if let Some(on_remove_elem) = &self.on_remove_element {
             on_remove_elem.call(element.clone());
         }
 
         let _ = element;
     }
-}
 
-#[cfg(feature = "web")]
-struct KeyAndElementFn {
-    key: Cow<'static, str>,
-    func: std::cell::RefCell<ElementFunc>,
-}
-
-#[cfg(feature = "web")]
-enum ElementFunc {
-    NoArgs(Box<dyn FnMut()>),
-    OneArg(Box<dyn FnMut(web_sys::Element)>),
-}
-
-#[cfg(feature = "web")]
-impl KeyAndElementFn {
-    fn call(&self, element: web_sys::Element) {
-        use std::ops::DerefMut;
-
-        match self.func.borrow_mut().deref_mut() {
-            ElementFunc::NoArgs(func) => (func)(),
-            ElementFunc::OneArg(func) => (func)(element),
-        };
+    pub(crate) fn map_dom<New: RealDom>(
+        self,
+        map: &dyn Fn(Box<dyn FnMut(Dom::Element)>) -> Box<dyn FnMut(New::Element)>,
+    ) -> SpecialAttributes<New> {
+        SpecialAttributes {
+            key: self.key,
+            on_create_element: self.on_create_element.map(|func| func.map_dom(map)),
+            on_remove_element: self.on_remove_element.map(|func| func.map_dom(map)),
+            dangerous_inner_html: self.dangerous_inner_html,
+        }
     }
 }
 
-#[cfg(feature = "web")]
-impl PartialEq for KeyAndElementFn {
+struct CreateOrRemoveElementFn<Dom: RealDom> {
+    func: RefCell<ElementFunc<Dom>>,
+}
+
+enum ElementFunc<Dom: RealDom> {
+    NoArgs(Box<dyn FnMut()>),
+    OneArg(Box<dyn FnMut(Dom::Element)>),
+}
+
+impl<Dom: RealDom> CreateOrRemoveElementFn<Dom> {
+    fn call(&self, element: Dom::Element) {
+        use std::ops::DerefMut;
+
+        match self.func.borrow_mut().deref_mut() {
+            ElementFunc::NoArgs(func) => func(),
+            ElementFunc::OneArg(func) => func(element),
+        };
+    }
+
+    fn map_dom<New: RealDom>(
+        self,
+        map: &dyn Fn(Box<dyn FnMut(Dom::Element)>) -> Box<dyn FnMut(New::Element)>,
+    ) -> CreateOrRemoveElementFn<New> {
+        let func = self.func.into_inner();
+        match func {
+            ElementFunc::NoArgs(func) => CreateOrRemoveElementFn {
+                func: RefCell::new(ElementFunc::NoArgs(func)),
+            },
+            ElementFunc::OneArg(func) => {
+                let func = map(func);
+                CreateOrRemoveElementFn {
+                    func: RefCell::new(ElementFunc::OneArg(func)),
+                }
+            }
+        }
+    }
+}
+
+impl<Dom: RealDom> PartialEq for CreateOrRemoveElementFn<Dom> {
     fn eq(&self, rhs: &Self) -> bool {
-        self.key == rhs.key
+        let _ = rhs;
+        // TODO: Arbitrarily chosen
+        true
+    }
+}
+
+impl<Dom: RealDom> Default for SpecialAttributes<Dom> {
+    fn default() -> Self {
+        Self {
+            key: None,
+            on_create_element: None,
+            on_remove_element: None,
+            dangerous_inner_html: None,
+        }
+    }
+}
+
+impl<Dom: RealDom> PartialEq for SpecialAttributes<Dom> {
+    fn eq(&self, other: &Self) -> bool {
+        let SpecialAttributes {
+            key: key_lhs,
+            on_create_element: on_create_element_lhs,
+            on_remove_element: on_remove_element_lhs,
+            dangerous_inner_html: dangerous_inner_html_lhs,
+        } = self;
+        let SpecialAttributes {
+            key: key_rhs,
+            on_create_element: on_create_element_rhs,
+            on_remove_element: on_remove_element_rhs,
+            dangerous_inner_html: dangerous_inner_html_rhs,
+        } = other;
+
+        key_lhs == key_rhs
+            && on_create_element_lhs == on_create_element_rhs
+            && on_remove_element_lhs == on_remove_element_rhs
+            && dangerous_inner_html_lhs == dangerous_inner_html_rhs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::VirtualElement;
+
+    /// Verify that we cannot set `on_create_element` if no `key` has been set.
+    #[test]
+    fn error_setting_on_create_element_if_no_key() {
+        let mut elem = create_div();
+
+        let err1 = elem
+            .special_attributes
+            .set_on_create_element(|_| {})
+            .err()
+            .unwrap();
+        let err2 = elem
+            .special_attributes
+            .set_on_create_element_no_args(|| {})
+            .err()
+            .unwrap();
+
+        assert!(matches!(err1, KeyNotSetError));
+        assert!(matches!(err2, KeyNotSetError));
+    }
+
+    /// Verify that we cannot set `on_remove_element` if no `key` has been set.
+    #[test]
+    fn error_setting_on_remove_element_if_no_key() {
+        let mut elem = create_div();
+        let special = &mut elem.special_attributes;
+
+        let err1 = special.set_on_remove_element(|_| {}).err().unwrap();
+        let err2 = special.set_on_remove_element_no_args(|| {}).err().unwrap();
+
+        assert!(matches!(err1, KeyNotSetError));
+        assert!(matches!(err2, KeyNotSetError));
+    }
+
+    /// Verify that [`SpecialAttributes::on_create_element_key`] only returns the key if
+    /// `on_create_element` is set.
+    #[test]
+    fn on_create_element_key() {
+        let mut elem = create_div();
+        let special = &mut elem.special_attributes;
+
+        special.set_key("hello");
+        assert_eq!(special.on_create_element_key(), None);
+
+        special.set_on_create_element(|_| {}).unwrap();
+        assert_eq!(
+            special.on_create_element_key().map(|key| key.as_ref()),
+            Some("hello")
+        );
+    }
+
+    /// Verify that [`SpecialAttributes::maybe_call_on_remove_element`] only returns the key if
+    /// `on_remove_element` is set.
+    #[test]
+    fn on_remove_element_key() {
+        let mut elem = create_div();
+        let special = &mut elem.special_attributes;
+
+        special.set_key("hello");
+        assert_eq!(special.on_remove_element_key(), None);
+
+        special.set_on_remove_element(|_| {}).unwrap();
+        assert_eq!(
+            special.on_remove_element_key().map(|key| key.as_ref()),
+            Some("hello")
+        );
+    }
+
+    fn create_div() -> VirtualElement<()> {
+        VirtualElement::new("div")
     }
 }


### PR DESCRIPTION
This commit makes it possible to set a `VirtualElement`'s key
independently.

Before this commit, one had to set the element's `on_create_element` or
`on_remove_element` when setting the key.
Now, a key can be set without setting those lifecycle methods.
